### PR TITLE
download_idp_metadata script to write idp metadata to a specified dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ All steps can be performed in an unattended fashion with:
 ```sh
 composer install --no-dev
 make
-bin/download_idp_metadata.php
+bin/download_idp_metadata.php ./example/idp_metadata
 ```
 
 **NOTE**: during testing, it is highly adviced to use the test Identity Provider [spid-testenv2](https://github.com/italia/spid-testenv2).

--- a/bin/download_idp_metadata.php
+++ b/bin/download_idp_metadata.php
@@ -1,14 +1,23 @@
 #!/usr/bin/php
 <?php
 // downloads the metadata for all current idps from the registry
-// and stores them all in the idp_metadata directory
+// and stores them all in the specified directory
 //
 // prerequisites:
-//   mkdir -p idp_metadata
 //   sudo apt install php-curl
+//
+// usage:
+//   ./bin/download_idp_metadata.php /tmp/idp_metadata
 //
 // Copyright (c) 2018, Paolo Greppi <paolo.greppi@simevo.com>
 // License: BSD 3-Clause
+
+if (count($argv) <= 1) {
+    echo "Usage: download_idp_metadata.php destination_dir_without_trailing_slash\n";
+    exit(-1);
+}
+
+$dir = $argv[1];
 
 $idp_list_url = 'https://registry.spid.gov.it/assets/data/idp.json';
 $ch = curl_init();
@@ -34,6 +43,6 @@ foreach ($idps->data as $idp) {
     echo "Contacting $metadata_url" . PHP_EOL;
     $xml = curl_exec($ch);
     curl_close($ch);
-    $file = "example/idp_metadata/$ipa_entity_code.xml";
+    $file = "$dir/$ipa_entity_code.xml";
     file_put_contents($file, $xml);
 }


### PR DESCRIPTION
the download_idp_metadata.php script can be useful for test automation

it was hardcoded to write the idp metadata to example/idp_metadata
but when spid-php-lib is to be used as a base for a framework / CMS
plugin, the location can be different (for example in the case of
spid-wordpress it can be /srv/spid-wordpress/idp_metadata)