### PR TITLE
fix #26: prevent backchannel comm between testenv2 and spid-php-lib example containers

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - type: bind
         source: ..
         target: /app
+    networks:
+      - example1
 
   spid-testenv2:
     image: italia/spid-testenv2
@@ -22,3 +24,11 @@ services:
       - type: bind
         source: ./spid-testenv2
         target: /app/conf
+    networks:
+      - example2
+
+networks:
+  example1:
+    driver: bridge
+  example2:
+    driver: bridge


### PR DESCRIPTION
references:
- https://docs.docker.com/network/network-tutorial-standalone/#use-user-defined-bridge-networks
- https://docs.docker.com/compose/compose-file/#networks

test:
```
docker network ls
docker network inspect example_example1 | grep IPv4Address
docker network inspect example_example2 | grep IPv4Address

docker ps
docker exec -it 8e bash # use container ID for example_example image
apt update
apt install iputils-ping
ping 172.19.0.2 # use IP addresses etrieved above
ping 172.20.0.2
```