### PR TITLE
implement `RequestedAuthnContext/@Comparison` customization and close #84

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ $settings = array(
     'sp_entityid' => SP_BASE_URL, // preferred: https protocol, no trailing slash, example: https://sp.example.com/
     'sp_key_file' => '/path/to/sp.key',
     'sp_cert_file' => '/path/to/sp.crt',
+    'sp_comparison' => 'exact', // one of: "exact", "minimum", "better" or "maximum"
     'sp_assertionconsumerservice' => [
         // order is important ! the 0-base index in this array will be used as ID in the calls
         SP_BASE_URL . '/acs',
@@ -274,7 +275,7 @@ A Docker-based demo application is available at [https://github.com/simevo/spid-
 |`AssertionConsumerServiceIndex` customization|✓|
 |`AttributeConsumingServiceIndex` customization|✓|
 |`AuthnContextClassRef` (SPID level) customization|✓|
-|`RequestedAuthnContext/@Comparison` customization||
+|`RequestedAuthnContext/@Comparison` customization|✓|
 |`RelayState` customization (1.2.2)|✓|
 |**Response/Assertion parsing**||
 |verification of `Signature` value (if any)|✓|

--- a/src/Spid/Interfaces/SAMLInterface.php
+++ b/src/Spid/Interfaces/SAMLInterface.php
@@ -11,6 +11,7 @@ interface SAMLInterface
     //     'sp_entityid' => SP_BASE_URL, // preferred: https, no trailing slash, example: https://sp.example.com/
     //     'sp_key_file' => '/path/to/sp.key',
     //     'sp_cert_file' => '/path/to/sp.crt',
+    //     'sp_comparison' => 'exact', // one of: 'exact', 'minimum', 'better', 'maximum'
     //     'sp_assertionconsumerservice' => [
     //         // order is important ! the 0-base index in this array will be used as ID in the calls
     //         SP_BASE_URL . '/acs',

--- a/src/Spid/Saml/Out/AuthnRequest.php
+++ b/src/Spid/Saml/Out/AuthnRequest.php
@@ -19,6 +19,11 @@ class AuthnRequest extends Base implements RequestInterface
         $attrID = $this->idp->attrID;
         $level = $this->idp->level;
         $force = $level > 1 ? "true" : "false";
+        if (isset($this->idp->sp->settings['sp_comparison'])) {
+            $comparison = $this->idp->sp->settings['sp_comparison'];
+        } else {
+            $comparison = "exact";
+        }
         
         $authnRequestXml = <<<XML
 <samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
@@ -33,7 +38,7 @@ class AuthnRequest extends Base implements RequestInterface
         NameQualifier="$entityId"
         Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">$entityId</saml:Issuer>
     <samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" />
-    <samlp:RequestedAuthnContext Comparison="exact">
+    <samlp:RequestedAuthnContext Comparison="$comparison">
         <saml:AuthnContextClassRef>https://www.spid.gov.it/SpidL$level</saml:AuthnContextClassRef>
     </samlp:RequestedAuthnContext>
 </samlp:AuthnRequest>

--- a/src/Spid/Saml/Out/AuthnRequest.php
+++ b/src/Spid/Saml/Out/AuthnRequest.php
@@ -18,12 +18,12 @@ class AuthnRequest extends Base implements RequestInterface
         $assertID = $this->idp->assertID;
         $attrID = $this->idp->attrID;
         $level = $this->idp->level;
-        $force = $level > 1 ? "true" : "false";
         if (isset($this->idp->sp->settings['sp_comparison'])) {
             $comparison = $this->idp->sp->settings['sp_comparison'];
         } else {
             $comparison = "exact";
         }
+        $force = ($level > 1 || $comparison == "minimum") ? "true" : "false";
         
         $authnRequestXml = <<<XML
 <samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"

--- a/src/Spid/Saml/Settings.php
+++ b/src/Spid/Saml/Settings.php
@@ -14,6 +14,7 @@ class Settings
         'sp_entityid' => self::REQUIRED,
         'sp_key_file' => self::REQUIRED,
         'sp_cert_file' => self::REQUIRED,
+        'sp_comparison' => self::NOT_REQUIRED,
         'sp_assertionconsumerservice' => self::REQUIRED,
         'sp_singlelogoutservice' => self::REQUIRED,
         'sp_attributeconsumingservice' => self::NOT_REQUIRED,
@@ -234,6 +235,15 @@ class Settings
             }
             if ($settings['accepted_clock_skew_seconds'] > 300) {
                 throw new \InvalidArgumentException('accepted_clock_skew_seconds should be at most 300 seconds');
+            }
+        }
+        if (isset($settings['sp_comparison'])) {
+            if (strcasecmp($settings['sp_comparison'], "exact") != 0 &&
+                strcasecmp($settings['sp_comparison'], "minimum") != 0 &&
+                strcasecmp($settings['sp_comparison'], "better") != 0 &&
+                strcasecmp($settings['sp_comparison'], "maximum") != 0) {
+                throw new \InvalidArgumentException('sp_comparison value should be one of:' .
+                    '"exact", "minimum", "better" or "maximum"');
             }
         }
     }

--- a/tests/SpTest.php
+++ b/tests/SpTest.php
@@ -140,6 +140,14 @@ final class SpTest extends PHPUnit\Framework\TestCase
         new Italia\Spid\Sp($settings);  
     }
 
+    public function testSettingsWithInvalidComparison()
+    {
+        $settings = self::$settings;
+        $this->expectException(InvalidArgumentException::class);
+        $settings['sp_comparison'] = "invalid";
+        new Italia\Spid\Sp($settings);
+    }
+
     public function testSettingsWithInvalidSpACS()
     {
         $settings = self::$settings;


### PR DESCRIPTION
the optional setting sp_comparison can be set to "exact", "minimum", "better" or "maximum"
this will affect Comparison attribute of the RequestedAuthnContext in the SP AuthnRequest message
if sp_comparison is not set, the Comparison will be requested "exact"