### PR TITLE
Response: check for subject element presence and non-emptyness

### DIFF
--- a/src/Spid/Saml/In/Response.php
+++ b/src/Spid/Saml/In/Response.php
@@ -90,6 +90,12 @@ class Response implements ResponseInterface
                 "entity'" . " but received " . $xml->getElementsByTagName('Issuer')->item(1)->getAttribute('Format'));
             }
 
+            if ($xml->getElementsByTagName('Subject')->length == 0) {
+                throw new \Exception("Missing Subject element");
+            } elseif (!$this->validateHasSubElements($xml->getElementsByTagName('Subject')->item(0))) {
+                throw new \Exception("Unspecified Subject element");
+            }
+
             if ($xml->getElementsByTagName('Conditions')->length == 0) {
                 throw new \Exception("Missing Conditions attribute");
             } elseif ($xml->getElementsByTagName('Conditions')->item(0)->getAttribute('NotBefore') == "") {
@@ -220,6 +226,17 @@ class Response implements ResponseInterface
         } else {
             return false;
         }
+    }
+
+    private function validateHasSubElements($parent)
+    {
+        foreach ($parent->childNodes as $node) {
+            if ($node->nodeType == XML_ELEMENT_NODE) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function spidSession(\DOMDocument $xml)


### PR DESCRIPTION
I'm in the process of validating a project that uses https://github.com/italia/spid-php-lib.
There are a few checks that fails in the response, I'll try to get the needed fixes into the library and open a few PRs to keep the changes small and readable.
Here's the first one, that adds a specific error message for the conditions tested in:
* 41 - Assertion - Elemento Subject non specificato
* 42 - Assertion - Elemento Subject mancante