### PR TITLE
Update Saml.php

### DIFF
--- a/src/Spid/Saml.php
+++ b/src/Spid/Saml.php
@@ -80,7 +80,7 @@ XML;
         $attrcsArray = $this->settings['sp_attributeconsumingservice'] ?? array();
 
         $xml = <<<XML
-<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="$entityID" ID="$id">
+<?xml version="1.0"?><md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="$entityID" ID="$id">
     <md:SPSSODescriptor
         protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"
         AuthnRequestsSigned="true" WantAssertionsSigned="true">


### PR DESCRIPTION
L'aggiunta dell'intestazione xml permette di generare un digest del file corretto e conforme alle specifiche SAML2 dettate da SPID