### PR TITLE
Added checks on login response required from demo validator

### DIFF
--- a/src/Spid/Saml/Idp.php
+++ b/src/Spid/Saml/Idp.php
@@ -96,7 +96,7 @@ class Idp implements IdpInterface
         $_SESSION['idpEntityId'] = $this->metadata['idpEntityId'];
         $_SESSION['acsUrl'] = $this->sp->settings['sp_assertionconsumerservice'][$ass];
         $_SESSION['level'] = $this->level; // For checking response 97 on demo validator
-		$_SESSION['comparison'] = $this->sp->settings['sp_comparison']; // For checking response 97 on demo validator
+        $_SESSION['comparison'] = $this->sp->settings['sp_comparison']; // For checking response 97 on demo validator
         $_SESSION['assertID'] = $this->assertID; // For checking response 103 on demo validator
 
         if (!$shouldRedirect || $binding == Settings::BINDING_POST) {

--- a/src/Spid/Saml/Idp.php
+++ b/src/Spid/Saml/Idp.php
@@ -95,6 +95,9 @@ class Idp implements IdpInterface
         $_SESSION['idpName'] = $this->idpFileName;
         $_SESSION['idpEntityId'] = $this->metadata['idpEntityId'];
         $_SESSION['acsUrl'] = $this->sp->settings['sp_assertionconsumerservice'][$ass];
+        $_SESSION['level'] = $this->level; // For checking response 97 on demo validator
+		$_SESSION['comparison'] = $this->sp->settings['sp_comparison']; // For checking response 97 on demo validator
+        $_SESSION['assertID'] = $this->assertID; // For checking response 103 on demo validator
 
         if (!$shouldRedirect || $binding == Settings::BINDING_POST) {
             return $url;

--- a/src/Spid/Saml/In/Response.php
+++ b/src/Spid/Saml/In/Response.php
@@ -23,7 +23,8 @@ class Response implements ResponseInterface
 
         $root = $xml->getElementsByTagName('Response')->item(0);
 
-        if ($root->getAttribute('ID') == null || $root->getAttribute('ID') == "") { // Check response 8 on demo validator
+        if ($root->getAttribute('ID') == null || $root->getAttribute('ID') == "") {
+            // Check response 8 on demo validator
             throw new \Exception("Missing ID attribute");
         }
 
@@ -38,7 +39,8 @@ class Response implements ResponseInterface
             throw new \Exception("Invalid IssueInstant attribute on Response");
         } elseif (strtotime($root->getAttribute('IssueInstant')) > strtotime('now') + $accepted_clock_skew_seconds) {
             throw new \Exception("IssueInstant attribute on Response is in the future");
-        } elseif (strtotime($root->getAttribute('IssueInstant')) < strtotime('now') - $accepted_clock_skew_seconds) { // Check response 14 on demo validator
+        } elseif (strtotime($root->getAttribute('IssueInstant')) < strtotime('now') - $accepted_clock_skew_seconds) {
+            // Check response 14 on demo validator
             throw new \Exception("IssueInstant attribute on Response is in the past");
         }
 
@@ -82,10 +84,12 @@ class Response implements ResponseInterface
             )) {
                 throw new \Exception("Invalid IssueInstant attribute on Assertion");
             } elseif (strtotime($xml->getElementsByTagName('Assertion')->item(0)->getAttribute('IssueInstant')) >
-                strtotime($root->getAttribute('IssueInstant'))) { // The issueInstant of assertion have to compared with issueInstant of the response, not with the current timestamp
+                strtotime($root->getAttribute('IssueInstant'))) {
+                    // The issueInstant of assertion have to compared with issueInstant of the response
                 throw new \Exception("IssueInstant attribute on Assertion is in the future");
-            } elseif (strtotime($xml->getElementsByTagName('Assertion')->item(0)->getAttribute('IssueInstant')) < // Check response 39 on demo validator
-                strtotime($root->getAttribute('IssueInstant'))) { // The issueInstant of assertion have to compared with issueInstant of the response, not with the current timestamp
+            } elseif (strtotime($xml->getElementsByTagName('Assertion')->item(0)->getAttribute('IssueInstant')) <
+                strtotime($root->getAttribute('IssueInstant'))) { // Check response 39 on demo validator
+                // The issueInstant of assertion have to compared with issueInstant of the response
                 throw new \Exception("IssueInstant attribute on Assertion is in the past");
             }
 
@@ -144,7 +148,8 @@ class Response implements ResponseInterface
                 } elseif ($xml->getElementsByTagName('NameID')->item(0)->getAttribute('NameQualifier') !=
                     $_SESSION['idpEntityId']) {
                     throw new \Exception("Invalid NameQualifier attribute, expected " . $_SESSION['idpEntityId'] .
-                        " but received " . $xml->getElementsByTagName('NameID')->item(0)->getAttribute('NameQualifier'));
+                        " but received " . 
+                        $xml->getElementsByTagName('NameID')->item(0)->getAttribute('NameQualifier'));
                 }
 
                 if ($xml->getElementsByTagName('SubjectConfirmation')->length > 0) {
@@ -171,20 +176,21 @@ class Response implements ResponseInterface
                             $xml->getElementsByTagName('SubjectConfirmation')->item(0)->getAttribute('Method'));
                     }
                 } else { // Check response 52 on demo validator
-					throw new \Exception("Missing SubjectConfirmation Element");
-				}
-
+                    throw new \Exception("Missing SubjectConfirmation Element");
+                }
             } else { // Check response 42 on demo validator
                 throw new \Exception("Missing Subject Element");
             }
 
             if ($xml->getElementsByTagName('AuthnStatement')->length > 0) {
                 // Check response 88 on demo validator
-                if ($xml->getElementsByTagName('AuthnContext')->length == 0) { // Check response 91 on demo validator
+                if ($xml->getElementsByTagName('AuthnContext')->length == 0) {
+                    // Check response 91 on demo validator
                     throw new \Exception("Missing AuthnContext element");
                 } else {
                     // Check response 90 on demo validator
-                    if ($xml->getElementsByTagName('AuthnContextClassRef')->length == 0) { // Check response 93 on demo validator
+                    if ($xml->getElementsByTagName('AuthnContextClassRef')->length == 0) {
+                        // Check response 93 on demo validator
                         throw new \Exception("Missing AuthnContextClassRef element");
                     } else {
                         $responseLevel = $xml->getElementsByTagName('AuthnContextClassRef')->item(0)->nodeValue;
@@ -193,7 +199,8 @@ class Response implements ResponseInterface
                             $len = strlen($responseLevel);
                             $responseLevelString = substr($responseLevel, -1 * (abs($len) + 1), -1);
                             if ($responseLevelString == "https://www.spid.gov.it/SpidL") {
-                                if ($responseLevel != "https://www.spid.gov.it/SpidL".$_SESSION['level']) { // Checking response 97 on demo validator
+                                if ($responseLevel != "https://www.spid.gov.it/SpidL".$_SESSION['level']) {
+                                    // Checking response 97 on demo validator
                                     if ($_SESSION['comparison'] == 'exact') {
                                         throw new \Exception("AuthnContextClassRef value inconsistent");
                                     } else {
@@ -218,42 +225,45 @@ class Response implements ResponseInterface
                     }
                 }
             } else { // Check response 89 on demo validator
-				throw new \Exception("Missing AuthnStatement Element");
-			}
+                throw new \Exception("Missing AuthnStatement Element");
+            }
 
             if ($xml->getElementsByTagName('Attribute')->length == 0) {
                 throw new \Exception("Missing Attribute Element");
             } else { // Check response 103 on demo validator
-				$countRequestAttribute = count($this->saml->settings['sp_attributeconsumingservice'][$_SESSION['assertID']]);
-				$countResponseAttribute = count($xml->getElementsByTagName('Attribute'));
-				if ($countRequestAttribute == $countResponseAttribute) { // Check the parameter number requested are equal to the received ones
-					$isFound = false;
-					$arrayResponseAttribute = array();
-					foreach ($xml->getElementsByTagName('Attribute') as $responseAttribute) {
-						array_push($arrayResponseAttribute, $responseAttribute->getAttribute('Name'));
-					}
-					foreach ($this->saml->settings['sp_attributeconsumingservice'][$_SESSION['assertID']] as &$requestAttribute) { // Check the parameter received are the same requested
-						$isFound = array_search($requestAttribute, $arrayResponseAttribute, false);
-						if ($isFound === false) {
+                $countRequestAttribute = count($this->saml->settings['sp_attributeconsumingservice'][$_SESSION['assertID']]);
+                $countResponseAttribute = count($xml->getElementsByTagName('Attribute'));
+                if ($countRequestAttribute == $countResponseAttribute) {
+                    // Check the parameter number requested are equal to the received ones
+                    $isFound = false;
+                    $arrayResponseAttribute = array();
+                    foreach ($xml->getElementsByTagName('Attribute') as $responseAttribute) {
+                        array_push($arrayResponseAttribute, $responseAttribute->getAttribute('Name'));
+                    }
+                    foreach ($this->saml->settings['sp_attributeconsumingservice'][$_SESSION['assertID']] as &$requestAttribute) {
+                        // Check the parameter received are the same requested
+                        $isFound = array_search($requestAttribute, $arrayResponseAttribute, false);
+                        if ($isFound === false) {
                             throw new \Exception("Missing attribute ".$requestAttribute);
-						} else {
-							$isFound = false;
-						}
-					}
-					unset($requestAttribute);
-				} else {
-					throw new \Exception("Parameter number requested are not equal to the received ones");
-				}
+                        } else {
+                            $isFound = false;
+                        }
+                    }
+                    unset($requestAttribute);
+                } else {
+                    throw new \Exception("Parameter number requested are not equal to the received ones");
+                }
                 
                 if ($xml->getElementsByTagName('AttributeValue')->length == 0) {
                     throw new \Exception("Missing AttributeValue Element");
                 }
             }
         } else { // Check response 32 on demo validator
-			if ($xml->getElementsByTagName('StatusCode')->item(0)->getAttribute('Value') == 'urn:oasis:names:tc:SAML:2.0:status:Success') {
+            if ($xml->getElementsByTagName('StatusCode')->item(0)->getAttribute('Value') ==
+            'urn:oasis:names:tc:SAML:2.0:status:Success') {
                 throw new \Exception("Missing Assertion Element");
-			}
-		}
+            }
+        }
 
         if ($xml->getElementsByTagName('Status')->length <= 0) {
             throw new \Exception("Missing Status element");
@@ -269,8 +279,10 @@ class Response implements ResponseInterface
         } elseif ($xml->getElementsByTagName('StatusCode')->item(0)->getAttribute('Value') !=
             'urn:oasis:names:tc:SAML:2.0:status:Success') {
              if ($xml->getElementsByTagName('StatusCode')->item(0)->getAttribute('Value') !=
-                'urn:oasis:names:tc:SAML:2.0:status:Requester' && $xml->getElementsByTagName('StatusCode')->item(0)->getAttribute('Value') !=
-                'urn:oasis:names:tc:SAML:2.0:status:Responder' && $xml->getElementsByTagName('StatusCode')->item(0)->getAttribute('Value') !=
+                'urn:oasis:names:tc:SAML:2.0:status:Requester' && 
+                $xml->getElementsByTagName('StatusCode')->item(0)->getAttribute('Value') !=
+                'urn:oasis:names:tc:SAML:2.0:status:Responder' && 
+                $xml->getElementsByTagName('StatusCode')->item(0)->getAttribute('Value') !=
                 'urn:oasis:names:tc:SAML:2.0:status:VersionMismatch') {
                     throw new \Exception("StatusCode not valid");
             } else {
@@ -297,7 +309,7 @@ class Response implements ResponseInterface
         unset($_SESSION['idpEntityId']);
         unset($_SESSION['acsUrl']);
         unset($_SESSION['comparison']);
-		unset($_SESSION['level']);
+        unset($_SESSION['level']);
         unset($_SESSION['assertID']);
         return true;
     }

--- a/src/Spid/Saml/In/Response.php
+++ b/src/Spid/Saml/In/Response.php
@@ -23,6 +23,10 @@ class Response implements ResponseInterface
 
         $root = $xml->getElementsByTagName('Response')->item(0);
 
+        if ($root->getAttribute('ID') == null || $root->getAttribute('ID') == "") { // Check response 8 on demo validator
+            throw new \Exception("Missing ID attribute");
+        }
+
         if ($root->getAttribute('Version') == "") {
             throw new \Exception("Missing Version attribute");
         } elseif ($root->getAttribute('Version') != '2.0') {
@@ -34,6 +38,8 @@ class Response implements ResponseInterface
             throw new \Exception("Invalid IssueInstant attribute on Response");
         } elseif (strtotime($root->getAttribute('IssueInstant')) > strtotime('now') + $accepted_clock_skew_seconds) {
             throw new \Exception("IssueInstant attribute on Response is in the future");
+        } elseif (strtotime($root->getAttribute('IssueInstant')) < strtotime('now') - $accepted_clock_skew_seconds) { // Check response 14 on demo validator
+            throw new \Exception("IssueInstant attribute on Response is in the past");
         }
 
         if ($root->getAttribute('InResponseTo') == "" || !isset($_SESSION['RequestID'])) {
@@ -76,8 +82,11 @@ class Response implements ResponseInterface
             )) {
                 throw new \Exception("Invalid IssueInstant attribute on Assertion");
             } elseif (strtotime($xml->getElementsByTagName('Assertion')->item(0)->getAttribute('IssueInstant')) >
-                strtotime('now') + $accepted_clock_skew_seconds) {
+                strtotime($root->getAttribute('IssueInstant'))) { // The issueInstant of assertion have to compared with issueInstant of the response, not with the current timestamp
                 throw new \Exception("IssueInstant attribute on Assertion is in the future");
+            } elseif (strtotime($xml->getElementsByTagName('Assertion')->item(0)->getAttribute('IssueInstant')) < // Check response 39 on demo validator
+                strtotime($root->getAttribute('IssueInstant'))) { // The issueInstant of assertion have to compared with issueInstant of the response, not with the current timestamp
+                throw new \Exception("IssueInstant attribute on Assertion is in the past");
             }
 
             // check item 1, this must be the Issuer element child of Assertion
@@ -123,51 +132,128 @@ class Response implements ResponseInterface
                 throw new \Exception("Invalid Audience attribute, expected " . $this->saml->settings['sp_entityid'] .
                     " but received " . $xml->getElementsByTagName('Audience')->item(0)->nodeValue);
             }
+            
+            if ($xml->getElementsByTagName('Subject')->length > 0) {
+                if ($xml->getElementsByTagName('NameID')->length == 0) {
+                    throw new \Exception("Missing NameID attribute");
+                } elseif ($xml->getElementsByTagName('NameID')->item(0)->getAttribute('Format') !=
+                    'urn:oasis:names:tc:SAML:2.0:nameid-format:transient') {
+                    throw new \Exception("Invalid NameID attribute, expected " .
+                    "'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'" . " but received " .
+                    $xml->getElementsByTagName('NameID')->item(0)->getAttribute('Format'));
+                } elseif ($xml->getElementsByTagName('NameID')->item(0)->getAttribute('NameQualifier') !=
+                    $_SESSION['idpEntityId']) {
+                    throw new \Exception("Invalid NameQualifier attribute, expected " . $_SESSION['idpEntityId'] .
+                        " but received " . $xml->getElementsByTagName('NameID')->item(0)->getAttribute('NameQualifier'));
+                }
 
-            if ($xml->getElementsByTagName('NameID')->length == 0) {
-                throw new \Exception("Missing NameID attribute");
-            } elseif ($xml->getElementsByTagName('NameID')->item(0)->getAttribute('Format') !=
-                'urn:oasis:names:tc:SAML:2.0:nameid-format:transient') {
-                throw new \Exception("Invalid NameID attribute, expected " .
-                "'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'" . " but received " .
-                $xml->getElementsByTagName('NameID')->item(0)->getAttribute('Format'));
-            } elseif ($xml->getElementsByTagName('NameID')->item(0)->getAttribute('NameQualifier') !=
-                $_SESSION['idpEntityId']) {
-                throw new \Exception("Invalid NameQualifier attribute, expected " . $_SESSION['idpEntityId'] .
-                    " but received " . $xml->getElementsByTagName('NameID')->item(0)->getAttribute('NameQualifier'));
+                if ($xml->getElementsByTagName('SubjectConfirmation')->length > 0) {
+                    if ($xml->getElementsByTagName('SubjectConfirmationData')->length == 0) {
+                        throw new \Exception("Missing SubjectConfirmationData attribute");
+                    } elseif ($xml->getElementsByTagName('SubjectConfirmationData')->item(0)->getAttribute('InResponseTo') !=
+                        $_SESSION['RequestID']) {
+                        throw new \Exception("Invalid SubjectConfirmationData attribute, expected " . $_SESSION['RequestID'] .
+                            " but received " .
+                            $xml->getElementsByTagName('SubjectConfirmationData')->item(0)->getAttribute('InResponseTo'));
+                    } elseif (strtotime(
+                        $xml->getElementsByTagName('SubjectConfirmationData')->item(0)->getAttribute('NotOnOrAfter')
+                    ) <= strtotime('now') - $accepted_clock_skew_seconds) {
+                        throw new \Exception("Invalid NotOnOrAfter attribute");
+                    } elseif ($xml->getElementsByTagName('SubjectConfirmationData')->item(0)->getAttribute('Recipient') !=
+                        $_SESSION['acsUrl']) {
+                        throw new \Exception("Invalid Recipient attribute, expected " . $_SESSION['acsUrl'] .
+                            " but received " .
+                            $xml->getElementsByTagName('SubjectConfirmationData')->item(0)->getAttribute('Recipient'));
+                    } elseif ($xml->getElementsByTagName('SubjectConfirmation')->item(0)->getAttribute('Method') !=
+                        'urn:oasis:names:tc:SAML:2.0:cm:bearer') {
+                        throw new \Exception("Invalid Method attribute, expected 'urn:oasis:names:tc:SAML:2.0:cm:bearer'" .
+                            " but received " .
+                            $xml->getElementsByTagName('SubjectConfirmation')->item(0)->getAttribute('Method'));
+                    }
+                } else { // Check response 52 on demo validator
+					throw new \Exception("Missing SubjectConfirmation Element");
+				}
+
+            } else { // Check response 42 on demo validator
+                throw new \Exception("Missing Subject Element");
             }
 
-            if ($xml->getElementsByTagName('SubjectConfirmationData')->length == 0) {
-                throw new \Exception("Missing SubjectConfirmationData attribute");
-            } elseif ($xml->getElementsByTagName('SubjectConfirmationData')->item(0)->getAttribute('InResponseTo') !=
-                $_SESSION['RequestID']) {
-                throw new \Exception("Invalid SubjectConfirmationData attribute, expected " . $_SESSION['RequestID'] .
-                    " but received " .
-                    $xml->getElementsByTagName('SubjectConfirmationData')->item(0)->getAttribute('InResponseTo'));
-            } elseif (strtotime(
-                $xml->getElementsByTagName('SubjectConfirmationData')->item(0)->getAttribute('NotOnOrAfter')
-            ) <= strtotime('now') - $accepted_clock_skew_seconds) {
-                throw new \Exception("Invalid NotOnOrAfter attribute");
-            } elseif ($xml->getElementsByTagName('SubjectConfirmationData')->item(0)->getAttribute('Recipient') !=
-                $_SESSION['acsUrl']) {
-                throw new \Exception("Invalid Recipient attribute, expected " . $_SESSION['acsUrl'] .
-                    " but received " .
-                    $xml->getElementsByTagName('SubjectConfirmationData')->item(0)->getAttribute('Recipient'));
-            } elseif ($xml->getElementsByTagName('SubjectConfirmation')->item(0)->getAttribute('Method') !=
-                'urn:oasis:names:tc:SAML:2.0:cm:bearer') {
-                throw new \Exception("Invalid Method attribute, expected 'urn:oasis:names:tc:SAML:2.0:cm:bearer'" .
-                    " but received " .
-                    $xml->getElementsByTagName('SubjectConfirmation')->item(0)->getAttribute('Method'));
-            }
+            if ($xml->getElementsByTagName('AuthnStatement')->length > 0) {
+                // Check response 88 on demo validator
+                if ($xml->getElementsByTagName('AuthnContext')->length == 0) { // Check response 91 on demo validator
+                    throw new \Exception("Missing AuthnContext element");
+                } else {
+                    // Check response 90 on demo validator
+                    if ($xml->getElementsByTagName('AuthnContextClassRef')->length == 0) { // Check response 93 on demo validator
+                        throw new \Exception("Missing AuthnContextClassRef element");
+                    } else {
+                        $responseLevel = $xml->getElementsByTagName('AuthnContextClassRef')->item(0)->nodeValue;
+                        $responseLevelInt = substr($responseLevel, -1);
+                        if ($responseLevelInt >= 1 || $responseLevelInt <= 3) {
+                            $len = strlen($responseLevel);
+                            $responseLevelString = substr($responseLevel, -1 * (abs($len) + 1), -1);
+                            if ($responseLevelString == "https://www.spid.gov.it/SpidL") {
+                                if ($responseLevel != "https://www.spid.gov.it/SpidL".$_SESSION['level']) { // Checking response 97 on demo validator
+                                    if ($_SESSION['comparison'] == 'exact') {
+                                        throw new \Exception("AuthnContextClassRef value inconsistent");
+                                    } else {
+                                        if ($responseLevelInt > $_SESSION['level']) {
+                                            if ($_SESSION['comparison'] == 'maximum') {
+                                                throw new \Exception("AuthnContextClassRef value inconsistent");
+                                            }
+                                        }
+                                        if ($responseLevelInt < $_SESSION['level']) {
+                                            if ($_SESSION['comparison'] == 'minimum') {
+                                                throw new \Exception("AuthnContextClassRef value inconsistent");
+                                            }
+                                        }
+                                    }
+                                }
+                            } else { // Check response 92, 97 on demo validator
+                                throw new \Exception("Invalid AuthnContextClassRef value");
+                            }
+                        } else { // Check response 97 on demo validator
+                            throw new \Exception("Invalid AuthnContextClassRef value");
+                        }
+                    }
+                }
+            } else { // Check response 89 on demo validator
+				throw new \Exception("Missing AuthnStatement Element");
+			}
 
             if ($xml->getElementsByTagName('Attribute')->length == 0) {
                 throw new \Exception("Missing Attribute Element");
+            } else { // Check response 103 on demo validator
+				$countRequestAttribute = count($this->saml->settings['sp_attributeconsumingservice'][$_SESSION['assertID']]);
+				$countResponseAttribute = count($xml->getElementsByTagName('Attribute'));
+				if ($countRequestAttribute == $countResponseAttribute) { // Check the parameter number requested are equal to the received ones
+					$isFound = false;
+					$arrayResponseAttribute = array();
+					foreach ($xml->getElementsByTagName('Attribute') as $responseAttribute) {
+						array_push($arrayResponseAttribute, $responseAttribute->getAttribute('Name'));
+					}
+					foreach ($this->saml->settings['sp_attributeconsumingservice'][$_SESSION['assertID']] as &$requestAttribute) { // Check the parameter received are the same requested
+						$isFound = array_search($requestAttribute, $arrayResponseAttribute, false);
+						if ($isFound === false) {
+                            throw new \Exception("Missing attribute ".$requestAttribute);
+						} else {
+							$isFound = false;
+						}
+					}
+					unset($requestAttribute);
+				} else {
+					throw new \Exception("Parameter number requested are not equal to the received ones");
+				}
+                
+                if ($xml->getElementsByTagName('AttributeValue')->length == 0) {
+                    throw new \Exception("Missing AttributeValue Element");
+                }
             }
-
-            if ($xml->getElementsByTagName('AttributeValue')->length == 0) {
-                throw new \Exception("Missing AttributeValue Element");
-            }
-        }
+        } else { // Check response 32 on demo validator
+			if ($xml->getElementsByTagName('StatusCode')->item(0)->getAttribute('Value') == 'urn:oasis:names:tc:SAML:2.0:status:Success') {
+                throw new \Exception("Missing Assertion Element");
+			}
+		}
 
         if ($xml->getElementsByTagName('Status')->length <= 0) {
             throw new \Exception("Missing Status element");
@@ -182,12 +268,19 @@ class Response implements ResponseInterface
             }
         } elseif ($xml->getElementsByTagName('StatusCode')->item(0)->getAttribute('Value') !=
             'urn:oasis:names:tc:SAML:2.0:status:Success') {
-            if ($xml->getElementsByTagName('StatusMessage')->item(0) != null) {
-                $StatusMessage = ' [message: ' . $xml->getElementsByTagName('StatusMessage')->item(0)->nodeValue . ']';
+             if ($xml->getElementsByTagName('StatusCode')->item(0)->getAttribute('Value') !=
+                'urn:oasis:names:tc:SAML:2.0:status:Requester' && $xml->getElementsByTagName('StatusCode')->item(0)->getAttribute('Value') !=
+                'urn:oasis:names:tc:SAML:2.0:status:Responder' && $xml->getElementsByTagName('StatusCode')->item(0)->getAttribute('Value') !=
+                'urn:oasis:names:tc:SAML:2.0:status:VersionMismatch') {
+                    throw new \Exception("StatusCode not valid");
             } else {
-                $StatusMessage = "";
+                if ($xml->getElementsByTagName('StatusMessage')->item(0) != null) {
+                    $StatusMessage = ' [message: ' . $xml->getElementsByTagName('StatusMessage')->item(0)->nodeValue . ']';
+                } else {
+                    $StatusMessage = "";
+                }
+                throw new \Exception("StatusCode is not Success" . $StatusMessage);
             }
-            throw new \Exception("StatusCode is not Success" . $StatusMessage);
         } elseif ($xml->getElementsByTagName('StatusCode')->item(1)->getAttribute('Value') ==
             'urn:oasis:names:tc:SAML:2.0:status:AuthnFailed') {
             throw new \Exception("AuthnFailed AuthnStatement element");
@@ -203,6 +296,9 @@ class Response implements ResponseInterface
         unset($_SESSION['idpName']);
         unset($_SESSION['idpEntityId']);
         unset($_SESSION['acsUrl']);
+        unset($_SESSION['comparison']);
+		unset($_SESSION['level']);
+        unset($_SESSION['assertID']);
         return true;
     }
 

--- a/src/Spid/Saml/In/Response.php
+++ b/src/Spid/Saml/In/Response.php
@@ -148,32 +148,33 @@ class Response implements ResponseInterface
                 } elseif ($xml->getElementsByTagName('NameID')->item(0)->getAttribute('NameQualifier') !=
                     $_SESSION['idpEntityId']) {
                     throw new \Exception("Invalid NameQualifier attribute, expected " . $_SESSION['idpEntityId'] .
-                        " but received " . 
+                        " but received " .
                         $xml->getElementsByTagName('NameID')->item(0)->getAttribute('NameQualifier'));
                 }
 
                 if ($xml->getElementsByTagName('SubjectConfirmation')->length > 0) {
                     if ($xml->getElementsByTagName('SubjectConfirmationData')->length == 0) {
                         throw new \Exception("Missing SubjectConfirmationData attribute");
-                    } elseif ($xml->getElementsByTagName('SubjectConfirmationData')->item(0)->getAttribute('InResponseTo') !=
-                        $_SESSION['RequestID']) {
-                        throw new \Exception("Invalid SubjectConfirmationData attribute, expected " . $_SESSION['RequestID'] .
-                            " but received " .
-                            $xml->getElementsByTagName('SubjectConfirmationData')->item(0)->getAttribute('InResponseTo'));
+                    } elseif ($xml->getElementsByTagName('SubjectConfirmationData')->item(0)->
+                        getAttribute('InResponseTo') != $_SESSION['RequestID']) {
+                        throw new \Exception("Invalid SubjectConfirmationData attribute, expected "
+                            . $_SESSION['RequestID'] . " but received " .
+                            $xml->getElementsByTagName('SubjectConfirmationData')->item(0)->
+                            getAttribute('InResponseTo'));
                     } elseif (strtotime(
                         $xml->getElementsByTagName('SubjectConfirmationData')->item(0)->getAttribute('NotOnOrAfter')
                     ) <= strtotime('now') - $accepted_clock_skew_seconds) {
                         throw new \Exception("Invalid NotOnOrAfter attribute");
-                    } elseif ($xml->getElementsByTagName('SubjectConfirmationData')->item(0)->getAttribute('Recipient') !=
-                        $_SESSION['acsUrl']) {
+                    } elseif ($xml->getElementsByTagName('SubjectConfirmationData')->item(0)->getAttribute('Recipient')
+                        != $_SESSION['acsUrl']) {
                         throw new \Exception("Invalid Recipient attribute, expected " . $_SESSION['acsUrl'] .
                             " but received " .
                             $xml->getElementsByTagName('SubjectConfirmationData')->item(0)->getAttribute('Recipient'));
                     } elseif ($xml->getElementsByTagName('SubjectConfirmation')->item(0)->getAttribute('Method') !=
                         'urn:oasis:names:tc:SAML:2.0:cm:bearer') {
-                        throw new \Exception("Invalid Method attribute, expected 'urn:oasis:names:tc:SAML:2.0:cm:bearer'" .
-                            " but received " .
-                            $xml->getElementsByTagName('SubjectConfirmation')->item(0)->getAttribute('Method'));
+                        throw new \Exception("Invalid Method attribute, expected "
+                            . "'urn:oasis:names:tc:SAML:2.0:cm:bearer' but received "
+                            . $xml->getElementsByTagName('SubjectConfirmation')->item(0)->getAttribute('Method'));
                     }
                 } else { // Check response 52 on demo validator
                     throw new \Exception("Missing SubjectConfirmation Element");
@@ -231,7 +232,8 @@ class Response implements ResponseInterface
             if ($xml->getElementsByTagName('Attribute')->length == 0) {
                 throw new \Exception("Missing Attribute Element");
             } else { // Check response 103 on demo validator
-                $countRequestAttribute = count($this->saml->settings['sp_attributeconsumingservice'][$_SESSION['assertID']]);
+                $countRequestAttribute = 
+                count($this->saml->settings['sp_attributeconsumingservice'][$_SESSION['assertID']]);
                 $countResponseAttribute = count($xml->getElementsByTagName('Attribute'));
                 if ($countRequestAttribute == $countResponseAttribute) {
                     // Check the parameter number requested are equal to the received ones
@@ -240,7 +242,8 @@ class Response implements ResponseInterface
                     foreach ($xml->getElementsByTagName('Attribute') as $responseAttribute) {
                         array_push($arrayResponseAttribute, $responseAttribute->getAttribute('Name'));
                     }
-                    foreach ($this->saml->settings['sp_attributeconsumingservice'][$_SESSION['assertID']] as &$requestAttribute) {
+                    foreach ($this->saml->settings['sp_attributeconsumingservice'][$_SESSION['assertID']]
+                    as &$requestAttribute) {
                         // Check the parameter received are the same requested
                         $isFound = array_search($requestAttribute, $arrayResponseAttribute, false);
                         if ($isFound === false) {
@@ -278,16 +281,17 @@ class Response implements ResponseInterface
             }
         } elseif ($xml->getElementsByTagName('StatusCode')->item(0)->getAttribute('Value') !=
             'urn:oasis:names:tc:SAML:2.0:status:Success') {
-             if ($xml->getElementsByTagName('StatusCode')->item(0)->getAttribute('Value') !=
-                'urn:oasis:names:tc:SAML:2.0:status:Requester' && 
+            if ($xml->getElementsByTagName('StatusCode')->item(0)->getAttribute('Value') !=
+                'urn:oasis:names:tc:SAML:2.0:status:Requester' &&
                 $xml->getElementsByTagName('StatusCode')->item(0)->getAttribute('Value') !=
-                'urn:oasis:names:tc:SAML:2.0:status:Responder' && 
+                'urn:oasis:names:tc:SAML:2.0:status:Responder' &&
                 $xml->getElementsByTagName('StatusCode')->item(0)->getAttribute('Value') !=
                 'urn:oasis:names:tc:SAML:2.0:status:VersionMismatch') {
                     throw new \Exception("StatusCode not valid");
             } else {
                 if ($xml->getElementsByTagName('StatusMessage')->item(0) != null) {
-                    $StatusMessage = ' [message: ' . $xml->getElementsByTagName('StatusMessage')->item(0)->nodeValue . ']';
+                    $StatusMessage = ' [message: '
+                    . $xml->getElementsByTagName('StatusMessage')->item(0)->nodeValue . ']';
                 } else {
                     $StatusMessage = "";
                 }


### PR DESCRIPTION
Managed the follows checks:
- "08. Response - ID non specificato";
- "14. Response - IssueInstant precedente Request";
- "32. Response - Elemento Assertion mancante";
- "39. Assertion - Attributo IssueInstant precedente a IssueInstant della Request";
- "40. Assertion - Attributo IssueInstant successivo a IssueInstant della Request";
- "42. Assertion - Elemento Subject mancante";
- "52. Assertion - Elemento SubjectConfirmation mancante";
- "88. Assertion - Elemento AuthStatement non specificato";
- "89. Assertion - Elemento AuthStatement mancante";
- "90. Assertion - Elemento AuthnContext di AuthStatement non specificato";
- "91. Assertion - Elemento AuthnContext di AuthStatement mancante";
- "92. Assertion - Elemento AuthContextClassRef di AuthnContext di AuthStatement non specificato";
- "93. Assertion - Elemento AuthContextClassRef di AuthnContext di AuthStatement mancante";
- "97. Assertion - Elemento AuthContextClassRef impostato ad un valore non previsto";
- "103. Assertion - Set di attributi inviato diverso da quello richiesto";