### PR TITLE
Fix PHPUnit test: 'Can load all idp metadata'

### DIFF
--- a/tests/SpTest.php
+++ b/tests/SpTest.php
@@ -296,14 +296,16 @@ final class SpTest extends PHPUnit\Framework\TestCase
             $retrievedIdp = $sp->loadIdpFromFile($idp);
             $this->assertEquals($retrievedIdp->idpFileName, $idp);
             $idpEntityId = $retrievedIdp->metadata['idpEntityId'];
-            $host = parse_url($idpEntityId, PHP_URL_HOST);
+            preg_match("/[a-z0-9\-]{1,63}\.[a-z\.]{2,6}$/", parse_url($idpEntityId, PHP_URL_HOST), $base_domain_tld);
             $idpSSOArray = $retrievedIdp->metadata['idpSSO'];
             foreach ($idpSSOArray as $key => $idpSSO) {
-                $this->assertStringContainsString($host, $idpSSO['location']);
+                preg_match("/[a-z0-9\-]{1,63}\.[a-z\.]{2,6}$/", parse_url($idpSSO['location'], PHP_URL_HOST), $domain_tld);
+                $this->assertStringContainsString($base_domain_tld[0], $domain_tld[0]);
             }
             $idpSLOArray = $retrievedIdp->metadata['idpSLO'];
             foreach ($idpSLOArray as $key => $idpSLO) {
-                $this->assertStringContainsString($host, $idpSLO['location']);
+                preg_match("/[a-z0-9\-]{1,63}\.[a-z\.]{2,6}$/", parse_url($idpSLO['location'], PHP_URL_HOST), $domain_tld);
+                $this->assertStringContainsString($base_domain_tld[0], $domain_tld[0]);
             }
         }
         // If IDPs were downloaded for testing purposes, then delete them


### PR DESCRIPTION
Come indicato nella issue https://github.com/italia/spid-php-lib/issues/148 il check viene eseguito sull'host che risulta essere diverso; il codice che propongo è di estrapolare il dominio di primo livello, per cui non mi aspetto che sia diverso.

Da capire se il test dovrebbe verificare solamente se il dato "Location" per SSO e SLO siano solamente presenti: in tal caso si potrebbe pensare di fare un semplice controllo sulla validazione dell'URL.