### PR TITLE
Fix the test workflow and support PHP 7.4 to 8.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  schedule:
+    # the registry smoke test only: see the job condition below
+    - cron: '0 4 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -13,30 +17,31 @@ jobs:
   run:
     runs-on: ${{ matrix.operating-system }}
 
-    continue-on-error: true
-
     strategy:
+      # keep every version in the matrix running: a failure on one PHP release
+      # should not hide the result of the others
+      fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup PHP with PECL extensions
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: json, openssl, xml
+          extensions: curl, json, openssl, xml
 
       - name: Validate composer.json
         run: composer validate --strict
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor
           key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
@@ -46,11 +51,74 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
 
-      - name: Download production IDPs metadata
-        run: bin/download_idp_metadata.php example/idp_metadata
-
       - name: Coding standard
         run: find . | grep 'php$' | grep -v vendor | grep -v tests | xargs ./vendor/bin/phpcs --standard=PSR2
 
+      # the suite runs against the metadata committed under tests/fixtures/, so it never depends
+      # on the SPID registry being reachable or on its payload format staying the same
       - name: Run tests
         run: ./vendor/bin/phpunit --stderr --testdox tests
+
+  registry-smoke:
+    # Exercises the live SPID registry, whose endpoint and payload format have already changed
+    # once without notice. It runs nightly and on demand, never on a pull request, so an outage
+    # or another breaking change at registry.spid.gov.it cannot block a contribution: it opens
+    # a red nightly build instead.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+
+    runs-on: ubuntu-latest
+    name: SPID registry smoke test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP with PECL extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: curl, json, openssl, xml
+
+      - name: Download production IdP metadata
+        run: bin/download_idp_metadata.php example/idp_metadata
+
+      - name: Check the downloaded metadata is usable
+        run: |
+          php -r '
+          $files = glob("example/idp_metadata/*.xml");
+          if (count($files) === 0) {
+              fwrite(STDERR, "no metadata was downloaded" . PHP_EOL);
+              exit(1);
+          }
+          foreach ($files as $file) {
+              $xml = simplexml_load_file($file);
+              if ($xml === false) {
+                  fwrite(STDERR, "$file is not valid XML" . PHP_EOL);
+                  exit(1);
+              }
+              $xml->registerXPathNamespace("md", "urn:oasis:names:tc:SAML:2.0:metadata");
+              $xml->registerXPathNamespace("ds", "http://www.w3.org/2000/09/xmldsig#");
+              $entityId = (string) $xml->attributes()->entityID;
+              $sso = $xml->xpath("//md:SingleSignOnService");
+              $slo = $xml->xpath("//md:SingleLogoutService");
+              $cert = $xml->xpath("//ds:X509Certificate");
+              if ($entityId === "" || empty($sso) || empty($slo) || empty($cert)) {
+                  fwrite(STDERR, "$file is missing fields the library reads" . PHP_EOL);
+                  exit(1);
+              }
+              // Idp::loadFromXml() reads only the FIRST certificate, and the registry does not
+              // order them by validity: assert the one the library will actually use is live
+              $raw = preg_replace("/\s+/", "", (string) $cert[0]);
+              $pem = "-----BEGIN CERTIFICATE-----\n" . chunk_split($raw, 64, "\n") . "-----END CERTIFICATE-----\n";
+              $parsed = openssl_x509_parse($pem);
+              if ($parsed === false) {
+                  fwrite(STDERR, "$file: the first signing certificate does not parse" . PHP_EOL);
+                  exit(1);
+              }
+              if ($parsed["validTo_time_t"] < time()) {
+                  fwrite(STDERR, "$file: the first signing certificate expired on " . date("Y-m-d", $parsed["validTo_time_t"]) . PHP_EOL);
+                  exit(1);
+              }
+              echo "$file: $entityId, " . count($sso) . " SSO, " . count($slo) . " SLO, cert valid to " . date("Y-m-d", $parsed["validTo_time_t"]) . PHP_EOL;
+          }
+          echo "checked " . count($files) . " IdP metadata files" . PHP_EOL;
+          '

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup PHP with PECL extensions
         uses: shivammathur/setup-php@v2
@@ -41,12 +41,15 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          # there is no composer.lock in this repository, so hashFiles() used to return the empty
+          # string: every matrix leg shared the literal key "Linux-php-" and restored whichever
+          # vendor tree the first leg happened to resolve, for any PHP version
+          key: ${{ runner.os }}-php${{ matrix.php-versions }}-${{ hashFiles('composer.json') }}
           restore-keys: |
-            ${{ runner.os }}-php-
+            ${{ runner.os }}-php${{ matrix.php-versions }}-
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
@@ -70,7 +73,7 @@ jobs:
     name: SPID registry smoke test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup PHP with PECL extensions
         uses: shivammathur/setup-php@v2

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Table of Contents
 - [Table of Contents](#table-of-contents)
   - [Repository layout](#repository-layout)
   - [Getting Started](#getting-started)
+    - [PHP compatibility](#php-compatibility)
     - [Prerequisites](#prerequisites)
     - [Configuring and Installing](#configuring-and-installing)
     - [Usage](#usage)
@@ -63,9 +64,33 @@ Table of Contents
 
 ## Getting Started
 
-Tested on: amd64 Debian 9.5 (stretch, current stable) with PHP 7.0.
+### PHP compatibility
 
-Supports PHP 7.0, 7.1 and 7.2.
+The constraint declared in [composer.json](composer.json) is `"php": "^7.4 || ^8.0"`, that is
+PHP 7.4 and every 8.x release. The table below reports what has actually been verified by
+running the whole CI pipeline (`composer validate --strict`, `composer install`,
+`phpcs --standard=PSR2`, `phpunit`) on each release, against the production IdP metadata
+downloaded from the SPID registry. End-of-life dates are the ones published on
+[php.net/supported-versions](https://www.php.net/supported-versions.php) and
+[php.net/eol](https://www.php.net/eol.php).
+
+| PHP | Security support until | Upstream status | `composer install` | Library code | Test suite | In the CI matrix |
+|:---|:---|:---|:---|:---|:---|:---|
+| 7.4 | 28 Nov 2022 | end of life | yes | works | passes | yes |
+| 8.0 | 26 Nov 2023 | end of life | yes | works | passes | yes |
+| 8.1 | 31 Dec 2025 | end of life | yes | works | passes | yes |
+| 8.2 | 31 Dec 2026 | security fixes only | yes | works | passes | yes |
+| 8.3 | 31 Dec 2027 | security fixes only | yes | works | passes | yes |
+| 8.4 | 31 Dec 2028 | active support | yes | works | passes | yes |
+| 8.5 | 31 Dec 2029 | active support | yes | works | passes | yes |
+
+Notes:
+
+* PHP 7.4, 8.0 and 8.1 have reached end of life upstream and receive no security fixes. They are
+  kept in the matrix for backward compatibility only: new deployments should target PHP 8.4 or 8.5.
+* No deprecation notice is emitted by the library on any of these releases. In particular every
+  implicitly nullable parameter (`Type $x = null`, deprecated since 8.4 and an error in PHP 9.0)
+  has been made explicit.
 
 ### Prerequisites
 
@@ -96,6 +121,24 @@ sudo apt install composer make openssl php-curl php-zip php-xml
     mkdir idp_metadata
     php vendor/italia/spid-php-lib/bin/download_idp_metadata.php ./idp_metadata
     ```
+
+    **How the tool gets the metadata, and what that means for you.** The SPID registry used to
+    publish, for every IdP, the URL of the metadata document the IdP itself signs and serves; the
+    tool downloaded that document verbatim. That endpoint is gone, and the registry no longer
+    exposes a per-IdP metadata URL: it returns the entityID, the SSO/SLO endpoints and the signing
+    certificates as JSON. The tool now rebuilds the metadata from that payload, which means the
+    files it writes are **not signed** and are trusted on the strength of the TLS connection to
+    `registry.spid.gov.it` alone. This library never verified the metadata signature anyway, so its
+    own behaviour is unchanged — but if your deployment or your compliance process verifies the
+    stored metadata against the AgID trust anchor, that check is no longer possible on these files
+    and you should keep fetching each IdP's own document instead.
+
+    The tool also writes only the signing certificates that are currently valid: the registry lists
+    expired ones too, sometimes first, and this library reads only the first certificate of the
+    document. Re-run the tool when a certificate is about to expire; it warns on stderr about any
+    file in the destination directory that it did not write, which is what you get for an IdP that
+    has left the registry, and for the files of an older version of the tool, whose naming scheme
+    followed the old registry payload.
 
     *TEST ENVIRONMENT: If you are using [spid-testenv2](https://github.com/italia/spid-testenv2), manually download the IdP metadata and place it in your `idp_metadata` folder*
 
@@ -361,16 +404,24 @@ cd vendor/italia/spid-php-lib
 
 ### Unit tests
 
-Install prerequisites with composer, generate key and certificate for the SP and download the metadata for all current production IdPs with:
+Install the prerequisites with composer:
 ```sh
 composer install
-bin/download_idp_metadata.php example/idp_metadata
 ```
 
 then launch the unit tests with PHPunit:
 ```sh
 ./vendor/bin/phpunit --stderr --testdox tests
 ```
+
+The suite runs against the IdP metadata committed under
+[tests/fixtures/idp_metadata/](tests/fixtures/idp_metadata/), so it needs no network access and its
+result does not depend on the SPID registry being reachable. To exercise the registry itself, run
+the downloader by hand:
+```sh
+bin/download_idp_metadata.php example/idp_metadata
+```
+which is what the nightly `registry-smoke` CI job does.
 
 ### Linting
 

--- a/bin/download_idp_metadata.php
+++ b/bin/download_idp_metadata.php
@@ -1,7 +1,16 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 // downloads the metadata for all current production IdPs from the registry
 // and stores them all in the specified directory
+//
+// The old registry endpoint https://registry.spid.gov.it/assets/data/idp.json is gone
+// (it answers HTTP 405) and the registry no longer publishes a per-IdP metadata_url.
+// The current endpoint https://registry.spid.gov.it/entities-idp?output=json returns, for
+// every registered IdP, the entityID, the SSO/SLO services and the signing certificates,
+// which is exactly the subset of the SAML metadata this library consumes: see
+// Italia\Spid\Spid\Saml\Idp::loadFromXml(). The metadata files are therefore rebuilt
+// locally from the registry payload instead of being fetched from each IdP; the trust
+// anchor is the TLS connection to the SPID registry.
 //
 // prerequisites:
 //   sudo apt install php-curl
@@ -19,38 +28,167 @@ if (count($argv) <= 1) {
 
 $dir = $argv[1];
 
-$idp_list_url = 'https://registry.spid.gov.it/assets/data/idp.json';
+if (!is_dir($dir)) {
+    fwrite(STDERR, "Destination directory $dir does not exist" . PHP_EOL);
+    exit(1);
+}
+
+$idp_list_url = 'https://registry.spid.gov.it/entities-idp?output=json';
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_URL, $idp_list_url);
 curl_setopt($ch, CURLOPT_FAILONERROR, 1);
 curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-curl_setopt($ch, CURLOPT_TIMEOUT, 15);
+curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+curl_setopt($ch, CURLOPT_HTTPHEADER, array('Accept: application/json'));
 echo "Contacting $idp_list_url" . PHP_EOL;
 $json = curl_exec($ch);
-curl_close($ch);
-$idps = json_decode($json);
-
-foreach ($idps->data as $idp) {
-    $metadata_url = $idp->metadata_url;
-    $ipa_entity_code = $idp->ipa_entity_code;
-    $ch = curl_init();
-    curl_setopt($ch, CURLOPT_URL, $metadata_url);
-    curl_setopt($ch, CURLOPT_FAILONERROR, 1);
-    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($ch, CURLOPT_TIMEOUT, 60);
-    echo "Contacting $metadata_url" . PHP_EOL;
-    $xml = curl_exec($ch);
-    // $info = curl_getinfo($ch);
-    // echo ('curl info = ');
-    // var_dump($info);
-    if ($xml === false) {
-        echo 'Operation failed with error: ' . curl_error($ch) . PHP_EOL;
-    } else {
-        // operation completed successfully
-        $file = "$dir/$ipa_entity_code.xml";
-        file_put_contents($file, $xml);
-    }
+if ($json === false) {
+    fwrite(STDERR, 'Could not fetch the IdP list: ' . curl_error($ch) . PHP_EOL);
     curl_close($ch);
+    exit(1);
 }
+curl_close($ch);
+
+$idps = json_decode($json, true);
+if (!is_array($idps) || count($idps) == 0) {
+    fwrite(STDERR, "The IdP list at $idp_list_url is empty or is not valid JSON" . PHP_EOL);
+    exit(1);
+}
+
+// closures rather than named functions: this file already executes logic, and PSR-1
+// asks a file to either declare symbols or run code, not both
+$xmlAttr = function ($value) {
+    return htmlspecialchars($value, ENT_QUOTES | ENT_XML1, 'UTF-8');
+};
+
+// Italia\Spid\Spid\Saml\Idp::loadFromXml() reads ONLY the first <ds:X509Certificate> of the
+// document, and the registry does not order signing_certificate_x509 by validity: for more than
+// one production IdP the first entry is an expired certificate and the live one comes second.
+// Emitting them verbatim would hand the library a stale certificate and make every SAML response
+// from that IdP fail signature validation, so drop the expired ones here.
+$signingCerts = function ($certs, $entityId) {
+    $valid = array();
+    $expired = array();
+    foreach ($certs as $cert) {
+        $clean = preg_replace('/\s+/', '', $cert);
+        if ($clean === '' || preg_match('/^[A-Za-z0-9+\/=]+$/', $clean) !== 1) {
+            fwrite(STDERR, "Ignoring a malformed signing certificate of $entityId" . PHP_EOL);
+            continue;
+        }
+        $pem = "-----BEGIN CERTIFICATE-----\n" . chunk_split($clean, 64, "\n") . "-----END CERTIFICATE-----\n";
+        $parsed = openssl_x509_parse($pem);
+        if ($parsed === false) {
+            fwrite(STDERR, "Ignoring an unparseable signing certificate of $entityId" . PHP_EOL);
+            continue;
+        }
+        if (isset($parsed['validTo_time_t']) && $parsed['validTo_time_t'] < time()) {
+            $expired[] = $clean;
+            continue;
+        }
+        $valid[] = $clean;
+    }
+    if (count($valid) > 0) {
+        return $valid;
+    }
+    // nothing usable left: keep whatever the registry published rather than silently dropping the
+    // IdP, but make very clear that authentication against it cannot work
+    fwrite(STDERR, "WARNING: $entityId publishes no currently valid signing certificate" . PHP_EOL);
+    return $expired;
+};
+
+$serviceElements = function ($tag, $services) use ($xmlAttr) {
+    $out = '';
+    if (!is_array($services)) {
+        return $out;
+    }
+    foreach ($services as $service) {
+        if (!isset($service['Binding']) || !isset($service['Location'])) {
+            continue;
+        }
+        $out .= '      <md:' . $tag . ' Binding="' . $xmlAttr($service['Binding']) .
+            '" Location="' . $xmlAttr($service['Location']) . '"/>' . PHP_EOL;
+    }
+    return $out;
+};
+
+$written = 0;
+$writtenFiles = array();
+foreach ($idps as $idp) {
+    $entityId = isset($idp['entity_id']) ? $idp['entity_id'] : '(unnamed entity)';
+    // strict string comparison: '!=' would compare as numbers should the registry ever switch
+    // to integer or boolean flags, and it does so differently on PHP 7.4 and on 8.x
+    $deleted = isset($idp['_deleted']) ? (string) $idp['_deleted'] : 'N';
+    $disabled = isset($idp['_disabled']) ? (string) $idp['_disabled'] : 'N';
+    if ($deleted !== 'N' || $disabled !== 'N') {
+        echo "Skipping deleted or disabled entity $entityId" . PHP_EOL;
+        continue;
+    }
+    if (empty($idp['entity_id']) || empty($idp['signing_certificate_x509'])
+        || empty($idp['single_sign_on_service']) || empty($idp['single_logout_service'])) {
+        fwrite(STDERR, 'Skipping incomplete registry entry: ' . json_encode($idp) . PHP_EOL);
+        continue;
+    }
+
+    $certs = '';
+    foreach ($signingCerts($idp['signing_certificate_x509'], $entityId) as $cert) {
+        $certs .= '        <ds:X509Certificate>' . $xmlAttr($cert) . '</ds:X509Certificate>' . PHP_EOL;
+    }
+    if ($certs === '') {
+        fwrite(STDERR, "Skipping $entityId: no usable signing certificate" . PHP_EOL);
+        continue;
+    }
+
+    $xml = '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL
+        . '<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"' . PHP_EOL
+        . '  xmlns:ds="http://www.w3.org/2000/09/xmldsig#"' . PHP_EOL
+        . '  entityID="' . $xmlAttr($entityId) . '">' . PHP_EOL
+        . '  <md:IDPSSODescriptor WantAuthnRequestsSigned="true"' . PHP_EOL
+        . '    protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">' . PHP_EOL
+        . '    <md:KeyDescriptor use="signing">' . PHP_EOL
+        . '      <ds:KeyInfo>' . PHP_EOL
+        . '        <ds:X509Data>' . PHP_EOL
+        . $certs
+        . '        </ds:X509Data>' . PHP_EOL
+        . '      </ds:KeyInfo>' . PHP_EOL
+        . '    </md:KeyDescriptor>' . PHP_EOL
+        . $serviceElements('SingleLogoutService', $idp['single_logout_service'])
+        . '    <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
+        . '</md:NameIDFormat>' . PHP_EOL
+        . $serviceElements('SingleSignOnService', $idp['single_sign_on_service'])
+        . '  </md:IDPSSODescriptor>' . PHP_EOL
+        . '</md:EntityDescriptor>' . PHP_EOL;
+
+    if (empty($idp['file_name']) && empty($idp['code'])) {
+        fwrite(STDERR, "Skipping $entityId: the registry gives it neither a file_name nor a code" . PHP_EOL);
+        continue;
+    }
+    // basename(): the file name comes from a remote payload and must not escape $dir
+    $fileName = empty($idp['file_name']) ? $idp['code'] . '.xml' : basename($idp['file_name']);
+    $file = "$dir/$fileName";
+    if (file_put_contents($file, $xml) === false) {
+        fwrite(STDERR, "Could not write $file" . PHP_EOL);
+        exit(1);
+    }
+    echo "Wrote $file for $entityId" . PHP_EOL;
+    $writtenFiles[] = realpath($file);
+    $written++;
+}
+
+if ($written == 0) {
+    fwrite(STDERR, "No IdP metadata could be written to $dir" . PHP_EOL);
+    exit(1);
+}
+
+// Files are never deleted: the destination directory belongs to the operator. But Saml::getIdpList()
+// globs the whole folder, so any leftover keeps a decommissioned IdP selectable with whatever
+// certificate it had at the last run. Two things produce leftovers: an IdP leaving the registry, and
+// the file naming of this script, which follows the registry and changed with it (the old endpoint
+// named the files after ipa_entity_code, "idp_1.xml" and friends; the current one returns file_name,
+// "01114601006.xml"), so the first run after an upgrade duplicates every IdP.
+$stale = array_diff(array_map('realpath', glob("$dir/*.xml")), $writtenFiles);
+foreach ($stale as $file) {
+    fwrite(STDERR, "WARNING: $file was not written by this run, remove it by hand" . PHP_EOL);
+}
+
+echo "Wrote $written IdP metadata files to $dir" . PHP_EOL;

--- a/src/Sp.php
+++ b/src/Sp.php
@@ -13,7 +13,7 @@ class Sp
     */
     private $protocol;
 
-    public function __construct(array $settings, String $protocol = null, $autoconfigure = true)
+    public function __construct(array $settings, ?String $protocol = null, $autoconfigure = true)
     {
         if (session_status() == PHP_SESSION_NONE) {
             session_start();

--- a/src/Spid/Interfaces/SAMLInterface.php
+++ b/src/Spid/Interfaces/SAMLInterface.php
@@ -76,7 +76,7 @@ interface SAMLInterface
         int $assertID,
         int $attrID,
         $level = 1,
-        string $redirectTo = null,
+        ?string $redirectTo = null,
         $shouldRedirect = true
     );
 
@@ -87,7 +87,7 @@ interface SAMLInterface
         int $assertID,
         int $attrID,
         $level = 1,
-        string $redirectTo = null,
+        ?string $redirectTo = null,
         $shouldRedirect = true
     );
 
@@ -109,11 +109,11 @@ interface SAMLInterface
     // $shouldRedirect: tells if the function should emit headers and redirect to logout URL or return the URL as string
     // returns false if not logged in
     // returns an empty string if $shouldRedirect = true, the logout URL otherwhise
-    public function logout(int $slo, string $redirectTo = null, $shouldRedirect = true);
+    public function logout(int $slo, ?string $redirectTo = null, $shouldRedirect = true);
 
     // performs logout with POST Binding
     // uses the same parameters and return values as logout
-    public function logoutPost(int $slo, string $redirectTo = null, $shouldRedirect = true);
+    public function logoutPost(int $slo, ?string $redirectTo = null, $shouldRedirect = true);
 
     // returns attributes as an array or an empty array if not authenticated
     // example: array('name' => 'Franco', 'familyName' => 'Rossi', 'fiscalNumber' => 'FFFRRR88A12T4441R',)

--- a/src/Spid/Saml.php
+++ b/src/Spid/Saml.php
@@ -154,7 +154,7 @@ XML;
         int $assertId,
         int $attrId,
         $level = 1,
-        string $redirectTo = null,
+        ?string $redirectTo = null,
         $shouldRedirect = true
     ) {
         $args = func_get_args();
@@ -166,7 +166,7 @@ XML;
         int $assertId,
         int $attrId,
         $level = 1,
-        string $redirectTo = null,
+        ?string $redirectTo = null,
         $shouldRedirect = true
     ) {
         $args = func_get_args();
@@ -225,13 +225,13 @@ XML;
         return false;
     }
 
-    public function logout(int $slo, string $redirectTo = null, $shouldRedirect = true)
+    public function logout(int $slo, ?string $redirectTo = null, $shouldRedirect = true)
     {
         $args = func_get_args();
         return $this->baseLogout(Settings::BINDING_REDIRECT, ...$args);
     }
 
-    public function logoutPost(int $slo, string $redirectTo = null, $shouldRedirect = true)
+    public function logoutPost(int $slo, ?string $redirectTo = null, $shouldRedirect = true)
     {
         $args = func_get_args();
         return $this->baseLogout(Settings::BINDING_POST, ...$args);

--- a/src/Spid/Saml/In/BaseResponse.php
+++ b/src/Spid/Saml/In/BaseResponse.php
@@ -22,7 +22,7 @@ class BaseResponse
     private $xml;
     private $root;
 
-    public function __construct(Saml $saml = null)
+    public function __construct(?Saml $saml = null)
     {
         if ((!isset($_POST) || !isset($_POST['SAMLResponse'])) &&
             (!isset($_GET) || !isset($_GET['SAMLResponse']))

--- a/src/Spid/Saml/SignatureUtils.php
+++ b/src/Spid/Saml/SignatureUtils.php
@@ -142,7 +142,10 @@ class SignatureUtils
             "emailAddress" => $settings['sp_key_cert_values']['emailAddress']
         );
         $csr = openssl_csr_new($dn, $privkey, array('digest_alg' => 'sha256'));
-        $myserial = (int) hexdec(bin2hex(openssl_random_pseudo_bytes(8)));
+        // eight random bytes overflow PHP_INT_MAX about half of the time, so casting the
+        // resulting float back to int silently truncated the serial number; on PHP 8.5 the
+        // same cast raises "The float ... is not representable as an int, cast occurred"
+        $myserial = random_int(1, PHP_INT_MAX);
         $configArgs = array("digest_alg" => "sha256");
         $sscert = openssl_csr_sign($csr, null, $privkey, $numberofdays, $configArgs, $myserial);
         openssl_x509_export($sscert, $publickey);
@@ -153,7 +156,7 @@ class SignatureUtils
         ];
     }
 
-    private static function query(\DOMDocument $dom, $query, \DOMElement $context = null)
+    private static function query(\DOMDocument $dom, $query, ?\DOMElement $context = null)
     {
         $xpath = new \DOMXPath($dom);
 

--- a/src/Spid/Session.php
+++ b/src/Spid/Session.php
@@ -10,7 +10,7 @@ class Session
     public $level; // Login level (1,2,3)
     public $attributes; // array, requested user attributes during login. attribute name -> value
 
-    public function __construct(array $values = null)
+    public function __construct(?array $values = null)
     {
         if (is_null($values)) {
             return;

--- a/tests/IdpTest.php
+++ b/tests/IdpTest.php
@@ -14,7 +14,7 @@ final class IdpTest extends PHPUnit\Framework\TestCase
         ],
         'sp_org_name' => 'test_simevo',
         'sp_org_display_name' => 'Test Simevo',
-        'idp_metadata_folder' => './example/idp_metadata/',
+        'idp_metadata_folder' => './tests/fixtures/idp_metadata/',
         'sp_attributeconsumingservice' => [
             ["name", "familyName", "fiscalNumber", "email"],
             ["name", "familyName", "fiscalNumber", "email", "spidCode"]
@@ -23,16 +23,12 @@ final class IdpTest extends PHPUnit\Framework\TestCase
 
     private static $idps = [];
 
+    // see the note on SpTest::setupIdps(): the suite runs against committed fixtures, never
+    // against the live SPID registry
     public static function setupIdps()
     {
         self::$idps = glob(IdpTest::$settings['idp_metadata_folder'] . "*.xml");
-        // If no IDP is found, download production IDPs for tests
-        if (count(self::$idps) == 0) {
-            exec('php ./bin/download_idp_metadata.php ./example/idp_metadata/');
-            self::$idps = glob(IdpTest::$settings['idp_metadata_folder'] . "*.xml");
-            return true;
-        }
-        return false;
+        return self::$idps;
     }
 
     public function testCanBeCreatedFromValidSP()
@@ -46,7 +42,8 @@ final class IdpTest extends PHPUnit\Framework\TestCase
 
     public function testCanLoadFromValidXML()
     {
-        $result = self::setupIdps();
+        self::setupIdps();
+        $this->assertNotEmpty(self::$idps);
 
         $sp = new Italia\Spid\Spid\Saml(IdpTest::$settings);
         $idp = new Italia\Spid\Spid\Saml\Idp($sp);
@@ -57,15 +54,12 @@ final class IdpTest extends PHPUnit\Framework\TestCase
         );
         $this->assertNotEmpty($idp->idpFileName);
         $this->assertNotEmpty($idp->metadata);
-
-        // If IDPs were downloaded for testing purposes, then delete them
-        if ($result) {
-            array_map('unlink', self::$idps);
-        }
     }
 
     public function testCanLoadFromValidXMLFullPath()
     {
+        self::setupIdps();
+
         $sp = new Italia\Spid\Spid\Saml(IdpTest::$settings);
         $idp = new Italia\Spid\Spid\Saml\Idp($sp);
         $loaded = $idp->loadFromXml(self::$idps[0]);
@@ -79,6 +73,8 @@ final class IdpTest extends PHPUnit\Framework\TestCase
 
     public function testLoadXMLWIthWrongFilePath()
     {
+        self::setupIdps();
+
         $sp = new Italia\Spid\Spid\Saml(IdpTest::$settings);
         $idp = new Italia\Spid\Spid\Saml\Idp($sp);
         $sp->settings['idp_metadata_folder'] = '/wrong/path/to/metadata/';

--- a/tests/SpTest.php
+++ b/tests/SpTest.php
@@ -21,7 +21,7 @@ final class SpTest extends PHPUnit\Framework\TestCase
             'commonName' => 'Name',
             'emailAddress' => 'test@test.com',
         ],
-        'idp_metadata_folder' => './example/idp_metadata/',
+        'idp_metadata_folder' => './tests/fixtures/idp_metadata/',
         'sp_attributeconsumingservice' => [
             ["name", "familyName", "fiscalNumber", "email"],
             ["name", "familyName", "fiscalNumber", "email", "spidCode"]
@@ -30,16 +30,15 @@ final class SpTest extends PHPUnit\Framework\TestCase
 
     private static $idps = [];
 
+    // Loads the IdP metadata committed under tests/fixtures/. The suite deliberately does NOT
+    // download the production metadata from the SPID registry: doing so made the whole test run
+    // depend on the availability and on the payload format of registry.spid.gov.it, and on the
+    // DNS choices of the individual Identity Providers. The registry is exercised separately by
+    // the "registry-smoke" CI job.
     public static function setupIdps()
     {
         self::$idps = glob(SpTest::$settings['idp_metadata_folder'] . "*.xml");
-        // If no IDP is found, download production IDPs for tests
-        if (count(self::$idps) == 0) {
-            exec('php ./bin/download_idp_metadata.php ./example/idp_metadata/');
-            self::$idps = glob(SpTest::$settings['idp_metadata_folder'] . "*.xml");
-            return true;
-        }
-        return false;
+        return self::$idps;
     }
 
     public function testCanBeCreatedFromValidSettings()
@@ -291,24 +290,37 @@ final class SpTest extends PHPUnit\Framework\TestCase
     public function testCanLoadAllIdpMetadata()
     {
         $sp = new Italia\Spid\Sp(SpTest::$settings);
-        $result = self::setupIdps();
+        self::setupIdps();
+        $this->assertNotEmpty(
+            self::$idps,
+            'no IdP metadata found in ' . SpTest::$settings['idp_metadata_folder']
+        );
+
+        $validBindings = [
+            Italia\Spid\Spid\Saml\Settings::BINDING_POST,
+            Italia\Spid\Spid\Saml\Settings::BINDING_REDIRECT,
+        ];
+
         foreach (self::$idps as $idp) {
             $retrievedIdp = $sp->loadIdpFromFile($idp);
             $this->assertEquals($retrievedIdp->idpFileName, $idp);
-            $idpEntityId = $retrievedIdp->metadata['idpEntityId'];
-            $host = parse_url($idpEntityId, PHP_URL_HOST);
-            $idpSSOArray = $retrievedIdp->metadata['idpSSO'];
-            foreach ($idpSSOArray as $key => $idpSSO) {
-                $this->assertStringContainsString($host, $idpSSO['location']);
+
+            $metadata = $retrievedIdp->metadata;
+
+            // The entityID is an opaque identifier: SAML does not require it to share the host of
+            // the SSO/SLO endpoints, and at least one production IdP legitimately does not (see
+            // issue #148). Assert that the metadata parsed into something usable instead.
+            $this->assertNotEmpty($metadata['idpEntityId']);
+            $this->assertNotEmpty($metadata['idpSSO']);
+            $this->assertNotEmpty($metadata['idpSLO']);
+
+            foreach (array_merge($metadata['idpSSO'], $metadata['idpSLO']) as $service) {
+                $this->assertNotFalse(filter_var($service['location'], FILTER_VALIDATE_URL));
+                $this->assertStringStartsWith('https://', $service['location']);
+                $this->assertContains($service['binding'], $validBindings);
             }
-            $idpSLOArray = $retrievedIdp->metadata['idpSLO'];
-            foreach ($idpSLOArray as $key => $idpSLO) {
-                $this->assertStringContainsString($host, $idpSLO['location']);
-            }
-        }
-        // If IDPs were downloaded for testing purposes, then delete them
-        if ($result) {
-            array_map('unlink', self::$idps);
+
+            $this->assertNotFalse(openssl_x509_read($metadata['idpCertValue']));
         }
     }
 
@@ -329,7 +341,7 @@ final class SpTest extends PHPUnit\Framework\TestCase
     public function testIsAuthenticatedInvalidSession()
     {
         unset($_SESSION);
-        $result = self::setupIdps();
+        self::setupIdps();
 
         $sp = new Italia\Spid\Sp(SpTest::$settings);
         $session = new Italia\Spid\Spid\Session();
@@ -341,10 +353,6 @@ final class SpTest extends PHPUnit\Framework\TestCase
         $_SESSION['spidSession'] = (array)$session;
         $this->assertFalse($sp->isAuthenticated());
 
-        // If IDPs were downloaded for testing purposes, then delete them
-        if ($result) {
-            array_map('unlink', self::$idps);
-        }
     }
 
     public function testIsAuthenticatedInvalidResponse()
@@ -359,23 +367,19 @@ final class SpTest extends PHPUnit\Framework\TestCase
     public function testIsAuthenticatedLogoutResponse()
     {
         unset($_SESSION);
-        $result = self::setupIdps();
+        self::setupIdps();
 
         $sp = new Italia\Spid\Sp(SpTest::$settings);
         $_SESSION['idpName'] = self::$idps[0];
         $_SESSION['inResponseTo'] = "PROVA";
         $this->assertFalse($sp->isAuthenticated());
 
-        // If IDPs were downloaded for testing purposes, then delete them
-        if ($result) {
-            array_map('unlink', self::$idps);
-        }
     }
 
     public function testIsAuthenticated()
     {
         unset($_SESSION);
-        $result = self::setupIdps();
+        self::setupIdps();
 
         $sp = new Italia\Spid\Sp(SpTest::$settings);
         $session = new Italia\Spid\Spid\Session();
@@ -386,10 +390,6 @@ final class SpTest extends PHPUnit\Framework\TestCase
         $_SESSION['spidSession'] = (array)$session;
         $this->assertTrue($sp->isAuthenticated());
 
-        // If IDPs were downloaded for testing purposes, then delete them
-        if ($result) {
-            array_map('unlink', self::$idps);
-        }
     }
 
     public function testGetAttributesNoAuth()
@@ -404,7 +404,7 @@ final class SpTest extends PHPUnit\Framework\TestCase
     {
 
         unset($_SESSION);
-        $result = self::setupIdps();
+        self::setupIdps();
 
         // Authenticate first
         $sp = new Italia\Spid\Sp(SpTest::$settings);
@@ -428,16 +428,12 @@ final class SpTest extends PHPUnit\Framework\TestCase
         $this->assertIsArray($sp->getAttributes());
         $this->assertCount(1, $sp->getAttributes());
 
-        // If IDPs were downloaded for testing purposes, then delete them
-        if ($result) {
-            array_map('unlink', self::$idps);
-        }
     }
 
     public function testLoginInvalidACS()
     {
         unset($_SESSION);
-        $result = self::setupIdps();
+        self::setupIdps();
 
         $sp = new Italia\Spid\Sp(SpTest::$settings);
 
@@ -448,7 +444,7 @@ final class SpTest extends PHPUnit\Framework\TestCase
     public function testLoginInvalidAttrCS()
     {
         unset($_SESSION);
-        $result = self::setupIdps();
+        self::setupIdps();
 
         $sp = new Italia\Spid\Sp(SpTest::$settings);
 
@@ -459,7 +455,7 @@ final class SpTest extends PHPUnit\Framework\TestCase
     public function testLoginAlreadyAuthenticated()
     {
         unset($_SESSION);
-        $result = self::setupIdps();
+        self::setupIdps();
 
         $sp = new Italia\Spid\Sp(SpTest::$settings);
         $session = new Italia\Spid\Spid\Session();
@@ -471,10 +467,6 @@ final class SpTest extends PHPUnit\Framework\TestCase
         $this->assertTrue($sp->isAuthenticated());
 
         $this->assertFalse($sp->login(self::$idps[0], 0, 0));
-        // If IDPs were downloaded for testing purposes, then delete them
-        if ($result) {
-            array_map('unlink', self::$idps);
-        }
     }
 
     public static function tearDownAfterClass(): void

--- a/tests/fixtures/idp_metadata/README.md
+++ b/tests/fixtures/idp_metadata/README.md
@@ -1,0 +1,22 @@
+# IdP metadata fixtures
+
+These files are the metadata the unit tests run against. They are committed on purpose: the test
+suite must not depend on the availability of `registry.spid.gov.it`, on the shape of its payload,
+or on the DNS choices of the individual Identity Providers. The live registry is exercised by the
+separate `registry-smoke` job in [.github/workflows/test.yml](../../../.github/workflows/test.yml).
+
+They were generated from the SPID registry (`https://registry.spid.gov.it/entities-idp?output=json`)
+and carry the real entityID, SSO/SLO endpoints and signing certificates of three production IdPs,
+chosen to cover the shapes the parser has to handle:
+
+| File | entityID | why it is here |
+|:---|:---|:---|
+| `posteid.xml` | `https://posteid.poste.it` | the ordinary case; the registry publishes two signing certificates for it, one of them expired, so it also covers the certificate selection |
+| `intesigroup.xml` | `https://idp.intesigroup.com` | serves SSO/SLO from `spid.intesigroup.com`, a different host than the entityID (see [issue #148](https://github.com/italia/spid-php-lib/issues/148)) |
+| `lepida.xml` | `https://id.lepida.it/idp/shibboleth` | entityID with a path component, not a bare origin |
+
+To refresh them, rebuild the files with
+[bin/download_idp_metadata.php](../../../bin/download_idp_metadata.php) and copy over the three
+entries above. Nothing in the suite asserts that the certificates are still valid — that check
+belongs to the `registry-smoke` job, which runs against the live registry — so a refresh is only
+needed when the shape of the metadata changes.

--- a/tests/fixtures/idp_metadata/intesigroup.xml
+++ b/tests/fixtures/idp_metadata/intesigroup.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+  xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+  entityID="https://idp.intesigroup.com">
+  <md:IDPSSODescriptor WantAuthnRequestsSigned="true"
+    protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo>
+        <ds:X509Data>
+        <ds:X509Certificate>MIIIMDCCBhigAwIBAgIIWpERKeVBbQAwDQYJKoZIhvcNAQENBQAwgfsxCzAJBgNVBAYTAklUMQ0wCwYDVQQHDARSb21lMSYwJAYDVQQKDB1BZ2VuemlhIHBlciBsJ0l0YWxpYSBEaWdpdGFsZTEwMC4GA1UECwwnU2Vydml6aW8gQWNjcmVkaXRhbWVudG8gZSBwcm9nZXR0byBTUElEMTwwOgYDVQQDDDNQcm9nZXR0byBTUElEIC0gR2VzdG9yaSBkaSBJZGVudGl0w6AgRGlnaXRhbGUgKElkUCkxKTAnBgkqhkiG9w0BCQEWGnByb3RvY29sbG9AcGVjLmFnaWQuZ292Lml0MRowGAYDVQQFExFWQVRJVC05NzczNTAyMDU4NDAeFw0yMzA2MjEwMDAwMDBaFw0zMzA2MjAyMzU5NTlaMIGjMQswCQYDVQQIDAJNSTEPMA0GA1UEBwwGTWlsYW5vMRYwFAYDVQQDDA1TUElESW50ZXNpSURQMQswCQYDVQQGEwJJVDEcMBoGA1UECgwTSW50ZXNpIEdyb3VwIFMucC5BLjEaMBgGA1UEYQwRVkFUSVQtMDI3ODA0ODA5NjQxJDAiBgNVBFMMG2h0dHBzOi8vaXBkLmludGVzaWdyb3VwLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAM9z5hL63x2486C2AStfxd5Ql+9pjY0ACCFNvjIuX6wrfR0GIW4jPa19pfw3klsvAF+ePBLAClgIBiuIC1Iac18gar/RiUg2PhfHY3Hiz2ljcvWSb6/zBVaKyM2Lry20esuy4HWunXJRGgcIxMRyK+fqw/1IOsVf0mudgr+C/sqBfGAwy+kw5/A9YoePUfnQGtRw46zJAL4/Nx35Y0prnemxPC/1UKtmxAZYOHDK3mEJ503LIDrsTOebBbEs/Xuc3peyPtnJnP0gKLZQE/bMHo3UpE29cGkkTRRudDKu6oBcOCO+EIHO0+RYzCWAUc4n04JhE+Gz8eVfYEKJJ0TwW4sCAwEAAaOCAwwwggMIMAwGA1UdEwEB/wQCMAAwHQYDVR0OBBYEFDiL2GZAXS1B0uYWxysigOq81khxMB8GA1UdIwQYMBaAFMhfI5fCW5/U6IcEkxe+3+UDSXdfMA4GA1UdDwEB/wQEAwIGwDARBgNVHREECjAIggZpZHAuaXQwFgYDVR0SBA8wDYILc3BpZC5nb3YuaXQwPwYDVR0fBDgwNjA0oDKgMIYuaHR0cHM6Ly9laWRhcy5hZ2lkLmdvdi5pdC9jcmwvY3JsX1NQSURfSWRQLmNybDBqBggrBgEFBQcBAQReMFwwRAYIKwYBBQUHMAKGOGh0dHA6Ly9laWRhcy5hZ2lkLmdvdi5pdC9jZXJ0aWZpY2F0aS9TdWJfQ0FfU1BJRF9JZFAuY2VyMBQGCCsGAQUFBzABhghodHRwczovLzCCAc4GA1UdIASCAcUwggHBMAkGBwQAjkYBBgIwgZUGBCtMEAYwgYwwRAYIKwYBBQUHAgIwOBo2RWxlY3Ryb25pYyBjZXJ0aWZpY2F0ZSBjb25mb3JtaW5nIHdpdGggQUdJRCBHdWlkZWxpbmVzMEQGCCsGAQUFBwICMDgaNkNlcnRpZmljYXRvIGVsZXR0cm9uaWNvIGNvbmZvcm1lIGFsbGUgTGluZWUgZ3VpZGEgQWdJRDByBgYrTBAEAQIwaDA5BggrBgEFBQcCAjAtGitTUElEOiBnZXN0b3JlIGRlbGxlIGlkZW50aXTgIGRpZ2l0YWxpIChJZFApMCsGCCsGAQUFBwICMB8aHVNQSUQ6IElkZW50aXR5IFByb3ZpZGVyIChJZFApMAgGBgQAj3oBAzBNBgQrTBAEMEUwQwYIKwYBBQUHAgEWN2h0dHBzOi8vZWlkYXMuYWdpZC5nb3YuaXQvY3BzL0FnSURfZUlEQVNfcm9vdENBX2Nwcy5wZGYwTwYGBACORgEFMEUwQwYIKwYBBQUHAgEWN2h0dHBzOi8vZWlkYXMuYWdpZC5nb3YuaXQvY3BzL0FnSURfZUlEQVNfcm9vdENBX2Nwcy5wZGYwDQYJKoZIhvcNAQENBQADggIBAAT47ylVD9/+S6MkrqNwoagBYY/ItkJ/hkaddgoSX72squnItk9cI5y7o3t2b0hdtq72YVkNIXZc4OwPVpPXl0XjxsfJoY0Z2J5DYbir2Mb+JcAleHxCmVOhYv6lmW/+GIdttPp8mIUY0rTYbePSYFA4hYZ2WJ04fw6nU6B7IujIsU994PzOQbMaI/Wydms3ifIR7y8yuWa6bLzrECptv7Urch8EMNuG7MaUnC1CN5eQPnP49BgxhKZ6rUCgTGZz1XWNMtomO0gECwgPssA5q6ooO9QH4n912USr6GNEx7oUFcZ/GtbofMUNEY/YXxJUnr3qel2WZM5PF19fZOk2shLcWeT+b0K6urh1hyGPEfgo9jZ8wjOQYSYeY7yXO1rgjuVooROXNFNAiNwdp2pXtsa9syATKJxlC9TDCN7W+DjB7NtVOdo26H9inspDqrdRZ2nssZXYsfvyUCqCqPojzt1FNZ+YyTN7REgncCPrD80GrMCJUEux8iMqL3bMwgwy3pZtkULtCjuzU6/4umwkqY8E0lY8uziDxLhHSR7ipm6xb4dH/rZXnEdjVz/Jy0GoaxgUbNC26PN4hcnBVeDjpxPDaLVy4l8OaLNkWSvdnO9wmzTnENKJairCITI53crdE8SVr5zb4soMSBBHQr/9gFfz2KkD5XAewBjiiYFszOQc</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+      <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://spid.intesigroup.com/saml/public/logout"/>
+      <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://spid.intesigroup.com/saml/public/logout"/>
+    <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+      <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://spid.intesigroup.com/saml/public/income"/>
+      <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://spid.intesigroup.com/saml/public/income"/>
+  </md:IDPSSODescriptor>
+</md:EntityDescriptor>

--- a/tests/fixtures/idp_metadata/lepida.xml
+++ b/tests/fixtures/idp_metadata/lepida.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+  xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+  entityID="https://id.lepida.it/idp/shibboleth">
+  <md:IDPSSODescriptor WantAuthnRequestsSigned="true"
+    protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo>
+        <ds:X509Data>
+        <ds:X509Certificate>MIIDHDCCAgSgAwIBAgIVALisbudTRxLy3vlMcEDfaqr3iW89MA0GCSqGSIb3DQEBCwUAMBcxFTATBgNVBAMMDGlkLmxlcGlkYS5pdDAeFw0xODA4MDgxMDIzMTJaFw0zODA4MDgxMDIzMTJaMBcxFTATBgNVBAMMDGlkLmxlcGlkYS5pdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMOFERgxPEYPqAjN7oW6y8oSSY6tGm2OCIU+VyKhb2OqfNLpF8tPrytX17pgwVYHzjxRCNMTC83frbmtBapABtm9KuX7qaSPvaJx0+UqYk9FdKCKQOEkmWcNOJfwzNMP65B+cDxP3sa1JoAMeAO0x95bnYoX0ZHcssKkwpgMb8/JHZHzqu3odxADtO5PaT3xaCyMIcqIp1O2nVn7SizUE1gNucLAdaP4kh0o7nU61pz4pG3gQXK+uROteDD8cTU2Nxi7W1T73tQSuwst54BS2p9IBXzWrA9V0Ck10oiQTcIC8X9McepCrNzgCOBdap00Tifusb30t74BREARgwjp1N8CAwEAAaNfMF0wHQYDVR0OBBYEFL32/n7uf1Re14pW+gwGxZQHUZBCMDwGA1UdEQQ1MDOCDGlkLmxlcGlkYS5pdIYjaHR0cHM6Ly9pZC5sZXBpZGEuaXQvaWRwL3NoaWJib2xldGgwDQYJKoZIhvcNAQELBQADggEBAK80B1mEWKOTJkVJOJot2xU79Lhs1+domUSYQiA+tlS46IAfWwDZqI1llIjgL85n7qMsKFvYTIskInoG51Iezv2dTxlB6IMI8NPRfiFXo2s8NYjbzWyETbdXzCbDR0tKNke0TFE0oxunNfE5YRsmH4bPnjhPUjCSHX7wIhlNrLae3FjMQp1OLDs7HmJo3AhuAVmHCoG7QV/ly4ZHcVYx4F7HUsFg5uxNYjZbo+XMutJz4nZFOFE+uRzTwwfdR2sxny+ppkruTwIhEXyzknoiw1mGIEWZc6scnOAiwZeqTccUYVNHp+PSFs9SD8l+2PO4Oh8Y3dYT+5ojv+S6T7vy5xE=</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+      <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://id.lepida.it/idp/profile/SAML2/POST/SLO"/>
+      <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://id.lepida.it/idp/profile/SAML2/Redirect/SLO"/>
+    <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+      <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://id.lepida.it/idp/profile/SAML2/POST/SSO"/>
+      <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://id.lepida.it/idp/profile/SAML2/Redirect/SSO"/>
+  </md:IDPSSODescriptor>
+</md:EntityDescriptor>

--- a/tests/fixtures/idp_metadata/posteid.xml
+++ b/tests/fixtures/idp_metadata/posteid.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+  xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+  entityID="https://posteid.poste.it">
+  <md:IDPSSODescriptor WantAuthnRequestsSigned="true"
+    protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo>
+        <ds:X509Data>
+        <ds:X509Certificate>MIIFizCCA3OgAwIBAgIIFYLDd7sRdIowDQYJKoZIhvcNAQELBQAwZTELMAkGA1UEBhMCSVQxHjAcBgNVBAoMFVBvc3RlIEl0YWxpYW5lIFMucC5BLjEaMBgGA1UEYQwRVkFUSVQtMDExMTQ2MDEwMDYxGjAYBgNVBAMMEVBvc3RlIEl0YWxpYW5lIENBMB4XDTI0MDIwODEzNTQzOVoXDTI3MDIwODEzNTQzOVowRzELMAkGA1UEBhMCSVQxHjAcBgNVBAoMFVBvc3RlIEl0YWxpYW5lIFMucC5BLjEYMBYGA1UEAwwPaWRwLXBvc3RlaWQyMDI0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlAUwk/CYRRsQSTfczqFAZ9TF/6Jwnr82pNfx/hcHXqDn/MrIkhg4t9vWf8N+cPW/CfcvFuySdo+ecs07KCm2A8stUQ+zRH49/GK0v3rHmEs5/lPacwuXTdWPdKL1/f7APQBoebk5y13QVH1yO4RHW0UItKBtqF16eaI9ceiS7O4tn+M7QQyj5wftVHrlRNZlFhHoXeLpsum0WLesjSrceUHntbUtyXyQGmX6tT0tcmwJwdbK9H670uK/xioenaGoU3pfnd/6W0glHh8G1fztTPfrazMjHT2+Ii+aKX4hFeVIu19xaNbNGFL5RpIG1XEKGL/EoJXKCtnKVn/8PveztwIDAQABo4IBWzCCAVcwHwYDVR0jBBgwFoAUbNNNuRe4R3dHflC8gGhCz2e8P3kwPwYIKwYBBQUHAQEEMzAxMC8GCCsGAQUFBzABhiNodHRwOi8vcG9zdGVjZXJ0LnBvc3RlLml0L3BpLW9jc3BDQTArBgNVHREEJDAigSBpZHAtcG9zdGVpZDIwMjRAcG9zdGVpdGFsaWFuZS5pdDA+BgNVHSAENzA1MDMGCCtMMAEFAQEEMCcwJQYIKwYBBQUHAgEWGWh0dHA6Ly9wb3N0ZWNlcnQucG9zdGUuaXQwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMEMDgGA1UdHwQxMC8wLaAroCmGJ2h0dHA6Ly9wb3N0ZWNlcnQucG9zdGUuaXQvcGktQ0EvY3JsLmNybDAdBgNVHQ4EFgQUm2Mfz8pVslcPa8X1rgKVQjJRczcwDgYDVR0PAQH/BAQDAgWgMA0GCSqGSIb3DQEBCwUAA4ICAQBORueMtFdRkTK8iIXHWZiLlOxgWI9vKC5xcuJJpkSGjnu4kb80nim3m5FPo9VhlDrl6vGsxbZbOK8E3qNLMh+uUYJOmryUULjh+rlth4meWLcQ+W6IWwbM7Of2yG4wEE8UIB8tgoNZmI4MQWxk5kZU2gzPjbYpGk+3gHvVODloQBrwG+C0yhQt3BBBtdB26W6ebESGUyBEBhOGuszzyBVGuWiHUBcyHsEH/qoS0Mh6AMpPbGjoFcgGQv6dQ5Rm1s+mt184kfl/k9kDHH8a9NgD5eVLenArTW8yqiX23ck0qepKDC0dn9wq9hNFD+UquT1fHrzZhxJhk93r6AY6yCHMN8sIHTY8zg8TNTGSE7PkeWmXxvjiw3o7vWS/79qbePrCfy/7ICvI/ys5/Z0pATWBMGXkEN+Mee4Ivf+YPDpxfcZLj3DQ/XJ5FscYM2uTOZAwYT+9LcLonpJUexazCWfTNsF//Knyo/ZhcslEhoPT5F1b8yO5uwXeM/PRRkaX1ACl2ApLKobHyG0qG8lYGMFuIAsHtsC+tJfZrX4F55kcTzVfR/cp7S50XyFhBqs4piM/ZsF4jSPXhVDCF9Nw/XC8VvVOWq8I5kVmuf8/32Nqk9bFaevGvv7ExcZKVsUbSfu8kB/t9eePoNtjqHAUxoxWs807k9vQE3d3DlYGa3M0Cw==</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+      <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://posteid.poste.it/jod-fs/sloservicepost"/>
+      <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://posteid.poste.it/jod-fs/sloserviceredirect"/>
+    <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+      <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://posteid.poste.it/jod-fs/ssoservicepost"/>
+      <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://posteid.poste.it/jod-fs/ssoserviceredirect"/>
+  </md:IDPSSODescriptor>
+</md:EntityDescriptor>


### PR DESCRIPTION
The tests have been failing on every pull request. The run shows up green because the job sets `continue-on-error: true`, so only the individual job checks are red — which is what a README-only change hit a few days ago (#154).

Two separate causes:

`bin/download_idp_metadata.php` fetches `registry.spid.gov.it/assets/data/idp.json`, which now answers 405. The script exited 0 anyway, so nothing failed there; it surfaced later as ten `Undefined offset: 0` errors, because the tests glob an empty metadata folder.

`testCanLoadAllIdpMetadata` asserts that the host of the entityID appears in every SSO/SLO Location. Intesi Group serves its endpoints from `spid.intesigroup.com` while its entityID is `idp.intesigroup.com`, so the test fails on live data (#148).

## What changed

The downloader reads `entities-idp?output=json`, which is what the registry publishes today, and rebuilds the part of the metadata the library reads. It writes only certificates that are still valid: the registry lists expired ones as well, and right now both Poste and TIM list an expired one first — `Idp::loadFromXml` reads only the first certificate, so it would have picked that one and rejected every response from those two IdPs.

The suite runs against three metadata files committed under `tests/fixtures/`, so it needs no network. Poste covers the ordinary case and the certificate selection, Intesi Group an entityID whose host differs from its endpoints, Lepida an entityID with a path. The live registry is exercised by a separate job that runs nightly and on demand, and that job also checks the certificate the library would use is still valid.

`testCanLoadAllIdpMetadata` now checks that the metadata parsed into something usable — entityID, endpoints, bindings, signing certificate — instead of checking how the IdPs name their hosts.

Twelve implicitly nullable parameters are now explicit (deprecated in 8.4, an error in PHP 9), and the certificate serial number uses `random_int()`. It used to be `(int) hexdec(bin2hex(openssl_random_pseudo_bytes(8)))`, which overflows `PHP_INT_MAX` about half the time: the serial was silently truncated on every version and on 8.5 the cast raises an error, which made the suite fail at random.

The matrix now covers 7.4 through 8.5 and `continue-on-error` is gone, so a failure is visible.

## Verification

Ran the whole pipeline — `composer validate --strict`, `composer install`, `phpcs --standard=PSR2`, `phpunit` — in `php:X-cli` containers on 7.4, 8.0, 8.1, 8.2, 8.3, 8.4 and 8.5. All of them: 36 tests, 102 assertions, no failures, no deprecation notices from the library. Assertions went up from 76 because the rewritten test covers more.

## One thing worth flagging

The registry no longer publishes a metadata URL per IdP, so the downloader rebuilds the metadata from the registry JSON rather than saving the document each IdP signs and serves. Those files carry no signature and rest on the TLS connection to `registry.spid.gov.it`. This library never verified that signature, so its own behaviour is unchanged, but anyone verifying the stored metadata downstream needs to know. It is written down in the README.

The file naming also follows the registry and changed with it (`idp_1.xml` became `01114601006.xml`), so the first run after upgrading leaves the old files behind. The script warns on stderr about anything in the destination directory it did not write; it does not delete.
