### PR TITLE
Fix SAML signature wrapping (XSW) allowing user impersonation

### DIFF
--- a/src/Spid/Saml/In/BaseResponse.php
+++ b/src/Spid/Saml/In/BaseResponse.php
@@ -73,9 +73,23 @@ class BaseResponse
         }
         
         $ns_saml = 'urn:oasis:names:tc:SAML:2.0:assertion';
-        $hasAssertion = $this->xml->getElementsByTagNameNS($ns_saml, 'Assertion')->length > 0;
-
+        $ns_samlp = 'urn:oasis:names:tc:SAML:2.0:protocol';
         $ns_signature = 'http://www.w3.org/2000/09/xmldsig#';
+
+        $assertions = $this->xml->getElementsByTagNameNS($ns_saml, 'Assertion');
+        $hasAssertion = $assertions->length > 0;
+
+        // A SPID response carries exactly one assertion inside exactly one
+        // protocol root. Refusing anything else removes the room a signature
+        // wrapping attack needs to smuggle a forged, unsigned assertion next to
+        // the genuine signed one (CWE-347, CWE-349, CWE-290).
+        if ($assertions->length > 1) {
+            throw new \Exception("Invalid Response. A Response must not contain more than one Assertion");
+        }
+        if ($this->xml->getElementsByTagNameNS($ns_samlp, $this->root)->length != 1) {
+            throw new \Exception("Invalid Response. Exactly one " . $this->root . " element is required");
+        }
+
         $signatures = $this->xml->getElementsByTagNameNS($ns_signature, 'Signature');
         if ($hasAssertion && $signatures->length == 0) {
             throw new \Exception("Invalid Response. Response must contain at least one signature");
@@ -85,11 +99,22 @@ class BaseResponse
         $assertionSignature = null;
         if ($signatures->length > 0) {
             foreach ($signatures as $key => $item) {
-                if ($item->parentNode->localName == 'Assertion') {
+                $parent = $item->parentNode;
+                // Only a signature directly protecting the assertion or the
+                // protocol root is meaningful; one placed anywhere else, or a
+                // second signature on the same element, is a wrapping attempt.
+                if ($parent->localName == 'Assertion' && $parent->namespaceURI == $ns_saml) {
+                    if (!is_null($assertionSignature)) {
+                        throw new \Exception("Invalid Response. The Assertion must not carry more than one signature");
+                    }
                     $assertionSignature = $item;
-                }
-                if ($item->parentNode->localName == $this->root) {
+                } elseif ($parent->localName == $this->root && $parent->namespaceURI == $ns_samlp) {
+                    if (!is_null($responseSignature)) {
+                        throw new \Exception("Invalid Response. The Response must not carry more than one signature");
+                    }
                     $responseSignature = $item;
+                } else {
+                    throw new \Exception("Invalid Response. Signature found in an unexpected position");
                 }
             }
             if ($hasAssertion && is_null($assertionSignature)) {
@@ -100,6 +125,41 @@ class BaseResponse
             !SignatureUtils::validateXmlSignature($assertionSignature, $cert)) {
             throw new \Exception("Invalid Response. Signature validation failed");
         }
+
+        // Defence in depth against signature wrapping: every identity-bearing
+        // element that the downstream validation and the attribute extraction
+        // read with getElementsByTagName(...)->item(0) MUST live inside the
+        // assertion that was just cryptographically validated. If any such
+        // element also appears outside it, item(0) could return the forged copy
+        // instead of the signed one, so the response is rejected.
+        if ($hasAssertion) {
+            $this->assertNoElementsOutsideAssertion($assertionSignature->parentNode);
+        }
+
         return $this->response->validate($this->xml, $hasAssertion);
+    }
+
+    // Rejects the response if any identity-bearing element exists outside the
+    // signed assertion. The counts are taken with getElementsByTagName(), i.e.
+    // by local name across every namespace, exactly like the code that later
+    // reads these elements, so a forged copy in a foreign namespace cannot slip
+    // through either.
+    private function assertNoElementsOutsideAssertion(\DOMElement $assertion)
+    {
+        $scopedTags = [
+            'Subject', 'NameID', 'SubjectConfirmation', 'SubjectConfirmationData',
+            'Conditions', 'AudienceRestriction', 'Audience',
+            'AuthnStatement', 'AuthnContextClassRef',
+            'AttributeStatement', 'Attribute', 'AttributeValue',
+        ];
+        foreach ($scopedTags as $tag) {
+            $inDocument = $this->xml->getElementsByTagName($tag)->length;
+            $inAssertion = $assertion->getElementsByTagName($tag)->length;
+            if ($inDocument !== $inAssertion) {
+                throw new \Exception(
+                    "Invalid Response. Unexpected " . $tag . " element found outside the signed assertion"
+                );
+            }
+        }
     }
 }

--- a/src/Spid/Saml/SignatureUtils.php
+++ b/src/Spid/Saml/SignatureUtils.php
@@ -68,18 +68,40 @@ class SignatureUtils
         return base64_encode($signature);
     }
 
+    // Validates the signature node $xml against the trusted certificate $cert.
+    //
+    // $xml is the <ds:Signature> element; the element it is meant to protect is
+    // its parent (the Response root or the Assertion). The signature is checked
+    // against ONLY that element, copied on its own into a fresh document, so that
+    // no other node elsewhere in the response can be substituted for the signed
+    // one. This closes the SAML signature wrapping (XSW) class of attacks, where
+    // a forged, unsigned assertion is smuggled next to the genuine signed one and
+    // the rest of the library ends up reading the forged copy
+    // (CWE-347, CWE-349, CWE-290).
     public static function validateXmlSignature($xml, $cert) : bool
     {
         if (is_null($xml)) {
             return true;
         }
-        $dom = clone $xml->ownerDocument;
 
+        $signedNode = $xml->parentNode;
+        if (is_null($signedNode)) {
+            return false;
+        }
+
+        // Copy the signed element, and only that element, into an isolated
+        // document. locateSignature() below then cannot pick a signature that
+        // lives somewhere else in the original response, and validateReference()
+        // can only resolve references that stay inside this subtree.
+        $dom = new \DOMDocument();
+        $dom->appendChild($dom->importNode($signedNode, true));
+
+        $x509 = $dom->getElementsByTagName('X509Certificate')->item(0);
+        if (is_null($x509)) {
+            return false;
+        }
         $certFingerprint = Settings::cleanOpenSsl($cert, true);
-        $signCertFingerprint = Settings::cleanOpenSsl(
-            $dom->getElementsByTagName('X509Certificate')->item(0)->nodeValue,
-            true
-        );
+        $signCertFingerprint = Settings::cleanOpenSsl($x509->nodeValue, true);
         if ($signCertFingerprint != $certFingerprint) {
             return false;
         }
@@ -88,21 +110,55 @@ class SignatureUtils
         $objXMLSecDSig->idKeys = array('ID');
 
         $objDSig = $objXMLSecDSig->locateSignature($dom);
+        if (is_null($objDSig)) {
+            return false;
+        }
         $objKey = $objXMLSecDSig->locateKey();
+        if (is_null($objKey)) {
+            return false;
+        }
 
         $objXMLSecDSig->canonicalizeSignedInfo();
 
         try {
-            $retVal = $objXMLSecDSig->validateReference();
-        } catch (Exception $e) {
-            throw $e;
+            if (!$objXMLSecDSig->validateReference()) {
+                return false;
+            }
+        } catch (\Exception $e) {
+            // A wrapped or tampered reference throws here: fail closed.
+            return false;
+        }
+
+        // The signature must actually cover the element it is attached to, not a
+        // nested node smuggled inside it: the enclosing element has to be among
+        // the nodes whose digest was just validated.
+        if (!self::signatureCoversNode($objXMLSecDSig, $dom->documentElement)) {
+            return false;
         }
 
         XMLSecEnc::staticLocateKeyInfo($objKey, $objDSig);
-        
+
         $objKey->loadKey($cert, false, true);
-        if ($objXMLSecDSig->verify($objKey) === 1) {
-            return true;
+        return $objXMLSecDSig->verify($objKey) === 1;
+    }
+
+    // Confirms that $node (the signed element) is one of the references the
+    // signature validated. Without this check a signature whose Reference points
+    // at a wrapped child element would still be accepted while the surrounding
+    // element it is attached to stays unsigned.
+    private static function signatureCoversNode(XMLSecurityDSig $objXMLSecDSig, \DOMNode $node) : bool
+    {
+        $validatedNodes = $objXMLSecDSig->getValidatedNodes();
+        if (!is_array($validatedNodes)) {
+            return false;
+        }
+        foreach ($validatedNodes as $validated) {
+            if ($validated instanceof \DOMDocument) {
+                $validated = $validated->documentElement;
+            }
+            if ($validated instanceof \DOMNode && $validated->isSameNode($node)) {
+                return true;
+            }
         }
         return false;
     }

--- a/tests/SignatureWrappingTest.php
+++ b/tests/SignatureWrappingTest.php
@@ -1,0 +1,324 @@
+<?php
+
+declare(strict_types=1);
+
+use Italia\Spid\Spid\Saml\SignatureUtils;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression tests for the SAML signature wrapping (XSW) vulnerability
+ * (CWE-347 / CWE-349 / CWE-290).
+ *
+ * The library used to validate the signature of the genuine assertion while the
+ * security checks and the attribute extraction read another, forged and unsigned,
+ * assertion smuggled into the same response. These tests build a genuinely signed
+ * response and a set of wrapping variations and assert that the honest response is
+ * accepted while every forged one is rejected.
+ */
+final class SignatureWrappingTest extends TestCase
+{
+    private static $dir;
+    private static $idpKey;
+    private static $idpCert;
+    private static $settings;
+
+    private static $idpEntityId = 'https://idp.example.com/';
+    private static $spEntityId = 'https://sp.example.com/';
+    private static $acsUrl = 'https://sp.example.com/acs';
+    private static $requestId = '_request0123456789abcdef';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$dir = sys_get_temp_dir() . '/spid_xsw_' . getmypid();
+        @mkdir(self::$dir);
+        @mkdir(self::$dir . '/idp_metadata');
+
+        $kc = SignatureUtils::generateKeyCert([
+            'sp_org_name' => 'idp',
+            'sp_org_display_name' => 'idp',
+            'sp_key_cert_values' => [
+                'countryName' => 'IT',
+                'stateOrProvinceName' => 'Rome',
+                'localityName' => 'Rome',
+                'commonName' => 'idp.example.com',
+                'emailAddress' => 'idp@example.com',
+            ],
+        ]);
+        self::$idpKey = self::$dir . '/idp.key';
+        self::$idpCert = self::$dir . '/idp.crt';
+        file_put_contents(self::$idpKey, $kc['key']);
+        file_put_contents(self::$idpCert, $kc['cert']);
+
+        $certClean = str_replace(
+            ['-----BEGIN CERTIFICATE-----', '-----END CERTIFICATE-----', "\r", "\n"],
+            '',
+            $kc['cert']
+        );
+        $metadata = '<?xml version="1.0"?>'
+            . '<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"'
+            . ' xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="' . self::$idpEntityId . '">'
+            . '<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">'
+            . '<md:KeyDescriptor use="signing"><ds:KeyInfo><ds:X509Data><ds:X509Certificate>'
+            . $certClean
+            . '</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor>'
+            . '<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"'
+            . ' Location="' . self::$idpEntityId . 'slo"/>'
+            . '<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"'
+            . ' Location="' . self::$idpEntityId . 'sso"/>'
+            . '</md:IDPSSODescriptor></md:EntityDescriptor>';
+        file_put_contents(self::$dir . '/idp_metadata/idp.xml', $metadata);
+
+        self::$settings = [
+            'sp_entityid' => self::$spEntityId,
+            'sp_key_file' => self::$dir . '/sp.key',
+            'sp_cert_file' => self::$dir . '/sp.crt',
+            'sp_assertionconsumerservice' => [self::$acsUrl],
+            'sp_singlelogoutservice' => [[self::$spEntityId . 'slo', '']],
+            'idp_metadata_folder' => self::$dir . '/idp_metadata/',
+        ];
+
+        // Start the PHP session up front so that populating $_SESSION in the
+        // individual tests is not wiped by the session_start() the first Sp
+        // instance would otherwise trigger.
+        if (session_status() === PHP_SESSION_NONE) {
+            @session_start();
+        }
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        foreach (glob(self::$dir . '/idp_metadata/*') ?: [] as $f) {
+            if (is_file($f)) {
+                unlink($f);
+            }
+        }
+        foreach (glob(self::$dir . '/*') ?: [] as $f) {
+            if (is_file($f)) {
+                unlink($f);
+            }
+        }
+        @rmdir(self::$dir . '/idp_metadata');
+        @rmdir(self::$dir);
+    }
+
+    protected function tearDown(): void
+    {
+        // Do not leak session/request state into the other test classes: the
+        // suite contains tests that assume an empty session.
+        $_SESSION = [];
+        unset($_POST['SAMLResponse'], $_GET['SAMLResponse']);
+    }
+
+    private function resetSession(): void
+    {
+        $_SESSION = [];
+        $_SESSION['idpName'] = self::$dir . '/idp_metadata/idp.xml';
+        $_SESSION['RequestID'] = self::$requestId;
+        $_SESSION['acsUrl'] = self::$acsUrl;
+        $_SESSION['idpEntityId'] = self::$idpEntityId;
+        unset($_GET['SAMLResponse']);
+    }
+
+    /**
+     * Builds a valid, standalone, signed <saml:Assertion>. $attrValue is the
+     * identity the assertion carries. Overrides let a test flip a single field.
+     */
+    private function signedAssertion(string $attrValue, array $overrides = []): string
+    {
+        $now = gmdate('Y-m-d\TH:i:s\Z');
+        $later = gmdate('Y-m-d\TH:i:s\Z', time() + 3600);
+        $v = array_merge([
+            'assertionId' => '_assertion0123456789abcdef',
+            'idpEntityId' => self::$idpEntityId,
+            'requestId' => self::$requestId,
+            'acsUrl' => self::$acsUrl,
+            'audience' => self::$spEntityId,
+        ], $overrides);
+
+        $assertion = '<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"'
+            . ' ID="' . $v['assertionId'] . '" Version="2.0" IssueInstant="' . $now . '">'
+            . '<saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">'
+            . $v['idpEntityId'] . '</saml:Issuer>'
+            . '<saml:Subject>'
+            . '<saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"'
+            . ' NameQualifier="' . $v['idpEntityId'] . '">_transient-name-id</saml:NameID>'
+            . '<saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">'
+            . '<saml:SubjectConfirmationData InResponseTo="' . $v['requestId'] . '"'
+            . ' NotOnOrAfter="' . $later . '" Recipient="' . $v['acsUrl'] . '"/>'
+            . '</saml:SubjectConfirmation></saml:Subject>'
+            . '<saml:Conditions NotBefore="' . $now . '" NotOnOrAfter="' . $later . '">'
+            . '<saml:AudienceRestriction><saml:Audience>' . $v['audience'] . '</saml:Audience>'
+            . '</saml:AudienceRestriction></saml:Conditions>'
+            . '<saml:AuthnStatement AuthnInstant="' . $now . '" SessionIndex="' . $v['assertionId'] . '">'
+            . '<saml:AuthnContext>'
+            . '<saml:AuthnContextClassRef>https://www.spid.gov.it/SpidL2</saml:AuthnContextClassRef>'
+            . '</saml:AuthnContext></saml:AuthnStatement>'
+            . '<saml:AttributeStatement>'
+            . '<saml:Attribute Name="fiscalNumber"><saml:AttributeValue>' . $attrValue
+            . '</saml:AttributeValue></saml:Attribute>'
+            . '</saml:AttributeStatement>'
+            . '</saml:Assertion>';
+
+        $signed = SignatureUtils::signXml(
+            $assertion,
+            ['sp_key_file' => self::$idpKey, 'sp_cert_file' => self::$idpCert]
+        );
+        // signXml returns a full document; drop the XML declaration so the result
+        // can be embedded inside a <samlp:Response>.
+        return preg_replace('/^<\?xml[^>]*\?>\s*/', '', $signed);
+    }
+
+    private function wrapInResponse(string $body): string
+    {
+        $now = gmdate('Y-m-d\TH:i:s\Z');
+        return '<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"'
+            . ' xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_response0123456789"'
+            . ' Version="2.0" IssueInstant="' . $now . '" InResponseTo="' . self::$requestId . '"'
+            . ' Destination="' . self::$acsUrl . '">'
+            . '<saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">'
+            . self::$idpEntityId . '</saml:Issuer>'
+            . '<samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>'
+            . $body
+            . '</samlp:Response>';
+    }
+
+    private function authenticate(string $responseXml): bool
+    {
+        // Build the Sp first: its constructor may call session_start(), which
+        // would reset $_SESSION. Populating the session afterwards keeps it.
+        $sp = new Italia\Spid\Sp(self::$settings, null, false);
+        $this->resetSession();
+        $_POST['SAMLResponse'] = base64_encode($responseXml);
+        try {
+            return $sp->isAuthenticated();
+        } finally {
+            unset($_POST['SAMLResponse']);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Baseline: an honestly signed response must be accepted (no regression).
+    // ---------------------------------------------------------------------
+    public function testGenuineSignedResponseIsAccepted(): void
+    {
+        $response = $this->wrapInResponse($this->signedAssertion('REAL-USER-FISCAL-CODE'));
+
+        $this->assertTrue($this->authenticate($response));
+        $this->assertSame(
+            'REAL-USER-FISCAL-CODE',
+            $_SESSION['spidSession']['attributes']['fiscalNumber'],
+            'The session must carry the attributes of the signed assertion'
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // The core attack from the bulletin: a forged, unsigned assertion placed
+    // before the genuine signed one. Must be rejected, and must NOT leak the
+    // attacker identity into the session.
+    // ---------------------------------------------------------------------
+    public function testForgedAssertionBeforeSignedOneIsRejected(): void
+    {
+        $forged = '<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"'
+            . ' ID="_forged" Version="2.0" IssueInstant="' . gmdate('Y-m-d\TH:i:s\Z') . '">'
+            . '<saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">'
+            . self::$idpEntityId . '</saml:Issuer>'
+            . '<saml:AttributeStatement><saml:Attribute Name="fiscalNumber">'
+            . '<saml:AttributeValue>ATTACKER-ADMIN</saml:AttributeValue></saml:Attribute>'
+            . '</saml:AttributeStatement></saml:Assertion>';
+
+        $response = $this->wrapInResponse($forged . $this->signedAssertion('REAL-USER-FISCAL-CODE'));
+
+        $this->expectException(\Exception::class);
+        try {
+            $this->authenticate($response);
+        } catch (\Exception $e) {
+            $this->assertArrayNotHasKey('spidSession', $_SESSION, 'No session must be created for a wrapped response');
+            throw $e;
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Wrapping variant: exactly one signed assertion, but a forged
+    // AttributeStatement is added at the response level, outside the assertion.
+    // item(0) would otherwise read it instead of the signed one.
+    // ---------------------------------------------------------------------
+    public function testForgedAttributeStatementOutsideAssertionIsRejected(): void
+    {
+        $forgedAttrs = '<saml:AttributeStatement><saml:Attribute Name="fiscalNumber">'
+            . '<saml:AttributeValue>ATTACKER-ADMIN</saml:AttributeValue></saml:Attribute>'
+            . '</saml:AttributeStatement>';
+
+        $response = $this->wrapInResponse($forgedAttrs . $this->signedAssertion('REAL-USER-FISCAL-CODE'));
+
+        $this->expectException(\Exception::class);
+        $this->authenticate($response);
+    }
+
+    // ---------------------------------------------------------------------
+    // Tampering with the signed assertion content must break the signature.
+    // ---------------------------------------------------------------------
+    public function testTamperedSignedAssertionIsRejected(): void
+    {
+        $signed = $this->signedAssertion('REAL-USER-FISCAL-CODE');
+        $tampered = str_replace('REAL-USER-FISCAL-CODE', 'ATTACKER-ADMIN', $signed);
+        $response = $this->wrapInResponse($tampered);
+
+        $this->expectException(\Exception::class);
+        $this->authenticate($response);
+    }
+
+    // ---------------------------------------------------------------------
+    // An assertion signed by a different (attacker) key must be rejected: its
+    // embedded certificate does not match the trusted IdP certificate.
+    // ---------------------------------------------------------------------
+    public function testAssertionSignedByUntrustedKeyIsRejected(): void
+    {
+        $rogue = SignatureUtils::generateKeyCert([
+            'sp_org_name' => 'rogue',
+            'sp_org_display_name' => 'rogue',
+            'sp_key_cert_values' => [
+                'countryName' => 'IT',
+                'stateOrProvinceName' => 'Rome',
+                'localityName' => 'Rome',
+                'commonName' => 'rogue.example.com',
+                'emailAddress' => 'rogue@example.com',
+            ],
+        ]);
+        $rogueKey = self::$dir . '/rogue.key';
+        $rogueCert = self::$dir . '/rogue.crt';
+        file_put_contents($rogueKey, $rogue['key']);
+        file_put_contents($rogueCert, $rogue['cert']);
+
+        $now = gmdate('Y-m-d\TH:i:s\Z');
+        $later = gmdate('Y-m-d\TH:i:s\Z', time() + 3600);
+        $assertion = '<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"'
+            . ' ID="_rogue" Version="2.0" IssueInstant="' . $now . '">'
+            . '<saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">'
+            . self::$idpEntityId . '</saml:Issuer>'
+            . '<saml:Subject><saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"'
+            . ' NameQualifier="' . self::$idpEntityId . '">_x</saml:NameID>'
+            . '<saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">'
+            . '<saml:SubjectConfirmationData InResponseTo="' . self::$requestId . '"'
+            . ' NotOnOrAfter="' . $later . '" Recipient="' . self::$acsUrl . '"/>'
+            . '</saml:SubjectConfirmation></saml:Subject>'
+            . '<saml:Conditions NotBefore="' . $now . '" NotOnOrAfter="' . $later . '">'
+            . '<saml:AudienceRestriction><saml:Audience>' . self::$spEntityId . '</saml:Audience>'
+            . '</saml:AudienceRestriction></saml:Conditions>'
+            . '<saml:AuthnStatement AuthnInstant="' . $now . '" SessionIndex="_rogue">'
+            . '<saml:AuthnContext><saml:AuthnContextClassRef>https://www.spid.gov.it/SpidL2'
+            . '</saml:AuthnContextClassRef></saml:AuthnContext></saml:AuthnStatement>'
+            . '<saml:AttributeStatement><saml:Attribute Name="fiscalNumber">'
+            . '<saml:AttributeValue>ATTACKER-ADMIN</saml:AttributeValue></saml:Attribute>'
+            . '</saml:AttributeStatement></saml:Assertion>';
+        $signed = preg_replace(
+            '/^<\?xml[^>]*\?>\s*/',
+            '',
+            SignatureUtils::signXml($assertion, ['sp_key_file' => $rogueKey, 'sp_cert_file' => $rogueCert])
+        );
+
+        $response = $this->wrapInResponse($signed);
+
+        $this->expectException(\Exception::class);
+        $this->authenticate($response);
+    }
+}


### PR DESCRIPTION
## Vulnerability

A crafted `SAMLResponse` carrying **two assertions** was accepted as authentic:

1. a forged, **unsigned** assertion holding the attacker's attributes, followed by
2. a genuine, **signed** assertion issued by a real Identity Provider.

The signature check found the single signature (on the second assertion) and validated it, while both the security checks in `Response::validate()` and the attribute extraction in `spidSession()` read the **first** assertion via `getElementsByTagName(...)->item(0)`. The element the library authenticated was therefore not the element it read the identity from: a classic SAML **signature wrapping (XSW)** attack allowing full impersonation of any user (**CWE-347**, **CWE-349**, **CWE-290**). The `spid-drupal-module` inherits the flaw and turns it into privilege escalation to administrator.

This was reported in a security bulletin covering `spid-php-lib` and dependent projects.

## Fix

Response validation is hardened in three layers so that the element the library reads is provably the element that was cryptographically validated:

- **`BaseResponse::validate()`** rejects any response that contains more than one `Assertion` or more than one protocol root, rejects a `Signature` placed anywhere other than the assertion or the root (and a second signature on the same element), and — as defence in depth — rejects any response in which an identity-bearing element (`NameID`, `Conditions`, `Audience`, `AttributeStatement`, `AttributeValue`, `AuthnContextClassRef`, …) appears **outside** the signed assertion. The counts mirror the namespace-agnostic `getElementsByTagName()` the downstream code uses, so a forged copy in a foreign namespace cannot slip through either.

- **`SignatureUtils::validateXmlSignature()`** now copies the signed element (and only that element) into an isolated document before verifying, instead of cloning the whole document and locating the *first* signature. It also confirms the enclosing element is actually among the nodes the reference digest covered, so a signature whose `Reference` points at a wrapped child cannot be passed off as covering its parent.

## Tests

`tests/SignatureWrappingTest.php` builds a genuinely signed response and the attack variants:

- ✅ genuine signed response is accepted and the session carries the **signed** assertion's attributes (no regression);
- ✅ forged unsigned assertion placed before the signed one → rejected, no session created;
- ✅ forged `AttributeStatement` at response level, outside the assertion → rejected;
- ✅ tampered signed assertion → rejected;
- ✅ assertion signed by an untrusted key → rejected.

## Verification

Full pipeline (`composer validate`, `phpcs --standard=PSR2`, `phpunit`) run in `php:X-cli` containers on **7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5** — 41 tests, 109 assertions, green on every version.

Supersedes the partial mitigation in #153 (thanks @VinsMach): that PR rejected multiple assertions and isolated the signed subtree; this PR keeps both ideas and adds the reference-coverage check and the "no identity element outside the signed assertion" defence, with regression tests.
