### PR TITLE
Reject a Response that carries no signed Assertion, and close the rest of the audit report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,12 @@ jobs:
       - name: Coding standard
         run: find . | grep 'php$' | grep -v vendor | grep -v tests | xargs ./vendor/bin/phpcs --standard=PSR2
 
+      # The signature validation is only as good as the XML security library
+      # underneath it, so a known advisory on a resolved dependency has to fail
+      # the build rather than wait to be noticed.
+      - name: Audit dependencies
+        run: composer audit
+
       # the suite runs against the metadata committed under tests/fixtures/, so it never depends
       # on the SPID registry being reachable or on its payload format staying the same
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -375,6 +375,36 @@ A Docker-based demo application is available at [https://github.com/simevo/spid-
 
 * [x] Generation of SPID button markup
 
+## Security requirements for integrators
+
+Some of the security properties of a SPID login depend on the application around
+this library, not only on the library itself.
+
+- **Select the Identity Provider by name, from a server-side list.** `login()` and
+  `loginPost()` take the identifier of an IdP whose metadata is in
+  `idp_metadata_folder`; the certificate in that metadata is the trust anchor used
+  to validate the Response. The library resolves the identifier inside the
+  configured folder and refuses paths, URLs and stream wrappers, but the
+  application should still validate the value against `getIdpList()` before passing
+  it on, as `example/views/login.php` does. Never pass a request parameter straight
+  to `login()`.
+- **Keep the metadata folder trustworthy.** Every `*.xml` in it is a trust anchor.
+  Only the IdP metadata your deployment has verified belongs there, and the
+  directory should not be writable by the web server. `bin/download_idp_metadata.php`
+  refreshes it from the SPID registry.
+- **Configure PHP sessions properly.** The library regenerates the session id when
+  the login completes, but the surrounding settings are the application's:
+  `session.use_strict_mode=1` and `session.use_only_cookies=1`, cookies marked
+  `Secure` and `HttpOnly` with an explicit `SameSite`, and HTTPS throughout.
+- **Check the level you get.** The level asserted by the IdP is validated against
+  the one requested in the AuthnRequest, following
+  `RequestedAuthnContext/@Comparison` (`sp_comparison`, `exact` by default). Read
+  `getAttributes()` and the session level rather than assuming the requested level
+  was honoured.
+- **Keep the dependencies current.** `robrichards/xmlseclibs` must be at least
+  3.1.5. Update `composer.lock` too, not just `composer.json`, and run
+  `composer audit` as part of your release.
+
 ## Troubleshooting
 
 It is advised to install a browser plugin to trace SAML messages:

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
         }
     ],
     "require": {
-        "robrichards/xmlseclibs": "^3.0",
+        "robrichards/xmlseclibs": "^3.1.5",
         "php": "^7.4 || ^8.0"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^3.3",
+        "squizlabs/php_codesniffer": "^3.13.6",
         "phpunit/phpunit": "^9.5"
     },
     "autoload": {

--- a/example/views/login.php
+++ b/example/views/login.php
@@ -1,9 +1,15 @@
 <?php
-if (isset($_POST) && isset($_POST['selected_idp'])) {
+// The Identity Provider is chosen with an identifier that must appear in the
+// server side list built from the metadata the deployment trusts. Never hand a
+// value taken from the request straight to login(): the metadata of the selected
+// Identity Provider supplies the certificate used to validate the SAML Response.
+$availableIdps = array_keys($sp->getIdpList());
+$idp = 'testenv';
+if (isset($_POST) && isset($_POST['selected_idp']) && in_array($_POST['selected_idp'], $availableIdps, true)) {
     $idp = $_POST['selected_idp'];
 }
 
-if (!$url = $sp->login($idp ?? 'testenv', 0, 1, 1, null, true)) {
+if (!$url = $sp->login($idp, 0, 1, 1, null, true)) {
     echo "Already logged in !<br>";
     echo "<a href=\"/\">Home</a>";
 } else {

--- a/src/Spid/Interfaces/ResponseInterface.php
+++ b/src/Spid/Interfaces/ResponseInterface.php
@@ -5,8 +5,11 @@ namespace Italia\Spid\Spid\Interfaces;
 interface ResponseInterface
 {
     // Validates a received response.
+    // $assertion is the <saml:Assertion> element whose signature has just been
+    // validated, or null for messages that carry no assertion. Identity data must
+    // be read from that element only, never from the document at large.
     // Throws exceptions on missing or invalid values.
     // returns false if resposne code is not success
     // returns true otherwise
-    public function validate($xml, $hasAssertion) : bool;
+    public function validate($xml, $assertion) : bool;
 }

--- a/src/Spid/Saml/Idp.php
+++ b/src/Spid/Saml/Idp.php
@@ -142,9 +142,18 @@ class Idp implements IdpInterface
     }
     public function authnRequest($ass, $attr, $binding, $level = 1, $redirectTo = null, $shouldRedirect = true) : string
     {
+        // Reject a level the SPID rules do not define before it is interpolated
+        // into the AuthnRequest (thanks to @VinsMach, italia/spid-php-lib#157).
+        // Comparing against the exact accepted values, rather than casting first,
+        // keeps something like "2; anything" from reaching the request as
+        // SpidL2; anything: only the normalised integer is kept.
+        if (!in_array($level, [1, 2, 3, '1', '2', '3'], true)) {
+            throw new \Exception("Invalid SPID level requested. Allowed values are 1, 2, 3.");
+        }
+
         $this->assertID = $ass;
         $this->attrID = $attr;
-        $this->level = $level;
+        $this->level = (int) $level;
 
         $authn = new AuthnRequest($this);
         $url = $binding == Settings::BINDING_REDIRECT ?

--- a/src/Spid/Saml/Idp.php
+++ b/src/Spid/Saml/Idp.php
@@ -25,17 +25,8 @@ class Idp implements IdpInterface
 
     public function loadFromXml($xmlFile)
     {
-        if (strpos($xmlFile, $this->sp->settings['idp_metadata_folder']) !== false) {
-            $fileName = $xmlFile;
-        } else {
-            $fileName = $this->sp->settings['idp_metadata_folder'] . $xmlFile . ".xml";
-        }
-        if (!file_exists($fileName)) {
-            throw new \Exception("Metadata file $fileName not found", 1);
-        }
-        if (!is_readable($fileName)) {
-            throw new \Exception("Metadata file $fileName is not readable. Please check file permissions.", 1);
-        }
+        $identifier = $this->idpIdentifier($xmlFile);
+        $fileName = $this->metadataFile($identifier);
         $xml = simplexml_load_file($fileName);
 
         $xml->registerXPathNamespace('md', 'urn:oasis:names:tc:SAML:2.0:metadata');
@@ -59,9 +50,77 @@ class Idp implements IdpInterface
         $metadata['idpSLO'] = $idpSLO;
         $metadata['idpCertValue'] = self::formatCert($xml->xpath('//ds:X509Certificate')[0]->__toString());
 
-        $this->idpFileName = $xmlFile;
+        $this->idpFileName = $identifier;
         $this->metadata = $metadata;
         return $this;
+    }
+
+    // Reduces whatever the caller passed to the bare name of an Identity Provider.
+    //
+    // The certificate found in this metadata is the trust anchor used later to
+    // validate the SAML Response, so whoever chooses the file chooses who may
+    // authenticate users. The previous implementation used the value as a file name
+    // as soon as it contained the configured folder anywhere inside it, which let a
+    // caller pass an absolute path, a traversal, a URL or a PHP stream wrapper and
+    // supply their own metadata, and therefore their own signing certificate.
+    // Any directory component is dropped here on purpose: an Identity Provider is
+    // named, never located, by the caller.
+    private function idpIdentifier($xmlFile) : string
+    {
+        if (!is_string($xmlFile) || $xmlFile === '' || strpos($xmlFile, "\0") !== false) {
+            throw new \Exception("Invalid Identity Provider identifier", 1);
+        }
+        // No URL and no PHP stream wrapper, whatever the rest of the value looks
+        // like: metadata is read from the local metadata folder, never fetched.
+        if (preg_match('#^[a-zA-Z][a-zA-Z0-9+.-]*://#', $xmlFile) === 1) {
+            throw new \Exception("Invalid Identity Provider identifier: a URL is not accepted", 1);
+        }
+
+        $normalized = str_replace('\\', '/', $xmlFile);
+        if (strpos($normalized, '/') !== false) {
+            // A path was supplied rather than a bare name. It is honoured only when
+            // it genuinely points at a file sitting directly in the configured
+            // folder, which is what getIdpList() passes; anything else, traversal
+            // and symbolic links out of the folder included, is refused here.
+            $folder = realpath($this->sp->settings['idp_metadata_folder']);
+            $resolved = realpath($normalized);
+            if ($folder === false || $resolved === false ||
+                dirname($resolved) !== $folder || !is_file($resolved)
+            ) {
+                throw new \Exception("Invalid Identity Provider identifier: " .
+                    "the metadata path is outside the configured folder", 1);
+            }
+        }
+
+        $identifier = basename($normalized, '.xml');
+        if (!preg_match('/^[A-Za-z0-9][A-Za-z0-9._-]*$/', $identifier) || strpos($identifier, '..') !== false) {
+            throw new \Exception("Invalid Identity Provider identifier", 1);
+        }
+        return $identifier;
+    }
+
+    // Resolves the identifier to a regular, readable file proven to sit directly
+    // inside the configured metadata folder, symbolic links included.
+    private function metadataFile(string $identifier) : string
+    {
+        $folder = realpath($this->sp->settings['idp_metadata_folder']);
+        if ($folder === false) {
+            throw new \Exception("The configured idp_metadata_folder does not exist", 1);
+        }
+        $fileName = realpath($folder . DIRECTORY_SEPARATOR . $identifier . '.xml');
+        if ($fileName === false) {
+            throw new \Exception("Metadata file $identifier not found", 1);
+        }
+        if (dirname($fileName) !== $folder) {
+            throw new \Exception("Metadata file $identifier is outside the configured metadata folder", 1);
+        }
+        if (!is_file($fileName)) {
+            throw new \Exception("Metadata file $identifier is not a regular file", 1);
+        }
+        if (!is_readable($fileName)) {
+            throw new \Exception("Metadata file $identifier is not readable. Please check file permissions.", 1);
+        }
+        return $fileName;
     }
 
     private static function formatCert($cert, $heads = true)
@@ -95,6 +154,10 @@ class Idp implements IdpInterface
         $_SESSION['idpName'] = $this->idpFileName;
         $_SESSION['idpEntityId'] = $this->metadata['idpEntityId'];
         $_SESSION['acsUrl'] = $this->sp->settings['sp_assertionconsumerservice'][$ass];
+        // Remember what was actually asked for: without it the response validation
+        // has nothing to compare the level the Identity Provider returns against.
+        $_SESSION['requestedLevel'] = $level;
+        $_SESSION['requestedComparison'] = $this->sp->settings['sp_comparison'] ?? 'exact';
 
         if (!$shouldRedirect || $binding == Settings::BINDING_POST) {
             return $url;
@@ -140,8 +203,12 @@ class Idp implements IdpInterface
         $url = ($binding == Settings::BINDING_REDIRECT) ?
             $logoutResponse->redirectUrl($redirectTo) :
             $logoutResponse->httpPost($redirectTo);
-        unset($_SESSION);
-        
+        // unset($_SESSION) only dropped this function's own reference to the
+        // superglobal, leaving the authenticated session intact after an Identity
+        // Provider initiated logout.
+        $_SESSION = array();
+        session_unset();
+
         if ($binding == Settings::BINDING_POST) {
             return $url;
             exit;

--- a/src/Spid/Saml/In/BaseResponse.php
+++ b/src/Spid/Saml/In/BaseResponse.php
@@ -18,26 +18,80 @@ use Italia\Spid\Spid\Saml;
 */
 class BaseResponse
 {
+    const NS_SAML = 'urn:oasis:names:tc:SAML:2.0:assertion';
+    const NS_SAMLP = 'urn:oasis:names:tc:SAML:2.0:protocol';
+    const NS_SIGNATURE = 'http://www.w3.org/2000/09/xmldsig#';
+
+    const STATUS_SUCCESS = 'urn:oasis:names:tc:SAML:2.0:status:Success';
+
+    // Signature algorithms accepted on an incoming HTTP-Redirect query string.
+    const REDIRECT_SIGNATURE_ALGOS = [
+        'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256' => OPENSSL_ALGO_SHA256,
+        'http://www.w3.org/2001/04/xmldsig-more#rsa-sha384' => OPENSSL_ALGO_SHA384,
+        'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512' => OPENSSL_ALGO_SHA512,
+    ];
+
     private $response;
     private $xml;
     private $root;
 
+    // Name of the HTTP parameter the message was read from, and whether it
+    // arrived through the HTTP-Redirect binding: the Redirect binding signs the
+    // query string instead of the XML, so the two need different verification.
+    private $messageParam;
+    private $isRedirect = false;
+
     public function __construct(?Saml $saml = null)
     {
-        if ((!isset($_POST) || !isset($_POST['SAMLResponse'])) &&
-            (!isset($_GET) || !isset($_GET['SAMLResponse']))
-        ) {
+        // An IdP initiated LogoutRequest travels in SAMLRequest, everything else
+        // in SAMLResponse. Ignoring SAMLRequest, as this used to, left the IdP
+        // initiated logout flow unreachable through its normal parameter.
+        foreach (['SAMLResponse', 'SAMLRequest'] as $param) {
+            if (isset($_GET) && isset($_GET[$param])) {
+                $this->messageParam = $param;
+                $this->isRedirect = true;
+                break;
+            }
+            if (isset($_POST) && isset($_POST[$param])) {
+                $this->messageParam = $param;
+                break;
+            }
+        }
+        if (is_null($this->messageParam)) {
             return;
         }
-        $xmlString = isset($_GET['SAMLResponse']) ?
-            gzinflate(base64_decode($_GET['SAMLResponse'])) :
-            base64_decode($_POST['SAMLResponse']);
-        
-        $this->xml = new \DOMDocument();
-        $this->xml->loadXML($xmlString);
 
-        $ns_samlp = 'urn:oasis:names:tc:SAML:2.0:protocol';
-        $this->root = $this->xml->getElementsByTagNameNS($ns_samlp, '*')->item(0)->localName;
+        $encoded = $this->isRedirect ? $_GET[$this->messageParam] : $_POST[$this->messageParam];
+        $decoded = base64_decode($encoded, true);
+        if ($decoded === false || $decoded === '') {
+            throw new \Exception('No valid response found');
+        }
+        if ($this->isRedirect) {
+            $decoded = @gzinflate($decoded);
+            if ($decoded === false || $decoded === '') {
+                throw new \Exception('No valid response found');
+            }
+        }
+
+        $this->xml = new \DOMDocument();
+        // LIBXML_NONET keeps libxml from reaching the network while parsing.
+        if (@$this->xml->loadXML($decoded, LIBXML_NONET) !== true) {
+            throw new \Exception('No valid response found');
+        }
+
+        // The message is the root of the document, not merely the first protocol
+        // element found somewhere inside it. Deciding the message type from a
+        // nested element would let an attacker wrap the real message in an
+        // envelope of their own and have the two read differently.
+        $rootElement = $this->xml->documentElement;
+        if (is_null($rootElement) || $rootElement->namespaceURI !== self::NS_SAMLP) {
+            throw new \Exception('No valid response found');
+        }
+        $this->root = $rootElement->localName;
+
+        if ($this->messageParam == 'SAMLRequest' && $this->root != 'LogoutRequest') {
+            throw new \Exception('No valid response found');
+        }
 
         switch ($this->root) {
             case 'Response':
@@ -71,59 +125,63 @@ class BaseResponse
         if (is_null($this->response)) {
             return true;
         }
-        
-        $ns_saml = 'urn:oasis:names:tc:SAML:2.0:assertion';
-        $ns_samlp = 'urn:oasis:names:tc:SAML:2.0:protocol';
-        $ns_signature = 'http://www.w3.org/2000/09/xmldsig#';
 
-        $assertions = $this->xml->getElementsByTagNameNS($ns_saml, 'Assertion');
-        $hasAssertion = $assertions->length > 0;
+        // Exactly one protocol element of the expected type, and it has to be the
+        // root: everything below reaches for elements by name, so a second one
+        // would be a place to hide a forged copy.
+        $roots = $this->xml->getElementsByTagNameNS(self::NS_SAMLP, $this->root);
+        if ($roots->length != 1 || !$roots->item(0)->isSameNode($this->xml->documentElement)) {
+            throw new \Exception("Invalid Response. Exactly one " . $this->root .
+                " element is required, as the root of the document");
+        }
 
-        // A SPID response carries exactly one assertion inside exactly one
-        // protocol root. Refusing anything else removes the room a signature
-        // wrapping attack needs to smuggle a forged, unsigned assertion next to
-        // the genuine signed one (CWE-347, CWE-349, CWE-290).
+        $assertions = $this->xml->getElementsByTagNameNS(self::NS_SAML, 'Assertion');
+        // A SPID response carries exactly one assertion. Refusing anything else
+        // removes the room a signature wrapping attack needs to smuggle a forged,
+        // unsigned assertion next to the genuine signed one (CWE-347, CWE-349,
+        // CWE-290).
         if ($assertions->length > 1) {
             throw new \Exception("Invalid Response. A Response must not contain more than one Assertion");
         }
-        if ($this->xml->getElementsByTagNameNS($ns_samlp, $this->root)->length != 1) {
-            throw new \Exception("Invalid Response. Exactly one " . $this->root . " element is required");
+        $assertion = $assertions->item(0);
+
+        // What has to be signed is decided by the type of message, NOT by what the
+        // message happens to contain. Deriving the requirement from the presence of
+        // an assertion, as this used to, meant an attacker could opt out of the
+        // signature check entirely just by sending a successful Response with no
+        // assertion at all, and the identity was then read from the unsigned
+        // document (CWE-347, CWE-290).
+        $needsSignedAssertion = $this->root == 'Response' && $this->isSuccess();
+
+        if ($needsSignedAssertion && is_null($assertion)) {
+            throw new \Exception("Invalid Response. A successful Response must contain exactly one Assertion");
+        }
+        if (!$needsSignedAssertion && !is_null($assertion)) {
+            throw new \Exception("Invalid Response. Unexpected Assertion in a " . $this->root);
         }
 
-        $signatures = $this->xml->getElementsByTagNameNS($ns_signature, 'Signature');
-        if ($hasAssertion && $signatures->length == 0) {
-            throw new \Exception("Invalid Response. Response must contain at least one signature");
+        list($responseSignature, $assertionSignature) = $this->locateSignatures($assertion);
+
+        if ($needsSignedAssertion && is_null($assertionSignature)) {
+            throw new \Exception("Invalid Response. The Assertion must be signed");
         }
 
-        $responseSignature = null;
-        $assertionSignature = null;
-        if ($signatures->length > 0) {
-            foreach ($signatures as $key => $item) {
-                $parent = $item->parentNode;
-                // Only a signature directly protecting the assertion or the
-                // protocol root is meaningful; one placed anywhere else, or a
-                // second signature on the same element, is a wrapping attempt.
-                if ($parent->localName == 'Assertion' && $parent->namespaceURI == $ns_saml) {
-                    if (!is_null($assertionSignature)) {
-                        throw new \Exception("Invalid Response. The Assertion must not carry more than one signature");
-                    }
-                    $assertionSignature = $item;
-                } elseif ($parent->localName == $this->root && $parent->namespaceURI == $ns_samlp) {
-                    if (!is_null($responseSignature)) {
-                        throw new \Exception("Invalid Response. The Response must not carry more than one signature");
-                    }
-                    $responseSignature = $item;
-                } else {
-                    throw new \Exception("Invalid Response. Signature found in an unexpected position");
-                }
-            }
-            if ($hasAssertion && is_null($assertionSignature)) {
-                throw new \Exception("Invalid Response. Assertion must be signed");
+        // Logout messages carry no assertion, so their own integrity is all there
+        // is: require it explicitly instead of accepting whatever turns up. Over
+        // the Redirect binding the signature covers the query string rather than
+        // the XML, so the two bindings are verified differently.
+        if ($this->root == 'LogoutResponse' || $this->root == 'LogoutRequest') {
+            if ($this->isRedirect) {
+                $this->validateQuerySignature($cert);
+            } elseif (is_null($responseSignature)) {
+                throw new \Exception("Invalid Response. The " . $this->root . " must be signed");
             }
         }
-        if (!SignatureUtils::validateXmlSignature($responseSignature, $cert) ||
-            !SignatureUtils::validateXmlSignature($assertionSignature, $cert)) {
-            throw new \Exception("Invalid Response. Signature validation failed");
+
+        foreach ([$responseSignature, $assertionSignature] as $signature) {
+            if (!is_null($signature) && !SignatureUtils::validateXmlSignature($signature, $cert)) {
+                throw new \Exception("Invalid Response. Signature validation failed");
+            }
         }
 
         // Defence in depth against signature wrapping: every identity-bearing
@@ -132,11 +190,121 @@ class BaseResponse
         // assertion that was just cryptographically validated. If any such
         // element also appears outside it, item(0) could return the forged copy
         // instead of the signed one, so the response is rejected.
-        if ($hasAssertion) {
-            $this->assertNoElementsOutsideAssertion($assertionSignature->parentNode);
+        if (!is_null($assertion)) {
+            $this->assertNoElementsOutsideAssertion($assertion);
         }
 
-        return $this->response->validate($this->xml, $hasAssertion);
+        return $this->response->validate($this->xml, $assertion);
+    }
+
+    // True when the message reports urn:oasis:names:tc:SAML:2.0:status:Success.
+    // The Status is read as a direct child of the root, because that is the only
+    // place where it belongs and the only one that cannot be shadowed.
+    private function isSuccess() : bool
+    {
+        foreach ($this->xml->documentElement->childNodes as $child) {
+            if (!($child instanceof \DOMElement)) {
+                continue;
+            }
+            if ($child->localName != 'Status' || $child->namespaceURI !== self::NS_SAMLP) {
+                continue;
+            }
+            foreach ($child->childNodes as $statusChild) {
+                if (!($statusChild instanceof \DOMElement)) {
+                    continue;
+                }
+                if ($statusChild->localName != 'StatusCode' || $statusChild->namespaceURI !== self::NS_SAMLP) {
+                    continue;
+                }
+                return $statusChild->getAttribute('Value') === self::STATUS_SUCCESS;
+            }
+        }
+        return false;
+    }
+
+    // Splits the signatures found in the document into the one protecting the
+    // root and the one protecting the assertion, refusing any other placement.
+    private function locateSignatures(?\DOMElement $assertion) : array
+    {
+        $responseSignature = null;
+        $assertionSignature = null;
+
+        $signatures = $this->xml->getElementsByTagNameNS(self::NS_SIGNATURE, 'Signature');
+        foreach ($signatures as $item) {
+            $parent = $item->parentNode;
+            // Only a signature directly protecting the assertion or the protocol
+            // root is meaningful; one placed anywhere else, or a second signature
+            // on the same element, is a wrapping attempt.
+            if (!is_null($assertion) && $parent->isSameNode($assertion)) {
+                if (!is_null($assertionSignature)) {
+                    throw new \Exception("Invalid Response. The Assertion must not carry more than one signature");
+                }
+                $assertionSignature = $item;
+            } elseif ($parent->isSameNode($this->xml->documentElement)) {
+                if (!is_null($responseSignature)) {
+                    throw new \Exception("Invalid Response. The " . $this->root .
+                        " must not carry more than one signature");
+                }
+                $responseSignature = $item;
+            } else {
+                throw new \Exception("Invalid Response. Signature found in an unexpected position");
+            }
+        }
+        return [$responseSignature, $assertionSignature];
+    }
+
+    // Verifies the HTTP-Redirect binding signature, which covers the exact
+    // sequence of query parameters rather than the XML document.
+    private function validateQuerySignature($cert)
+    {
+        if (!isset($_GET['Signature']) || !isset($_GET['SigAlg'])) {
+            throw new \Exception("Invalid Response. Missing Signature or SigAlg on the query string");
+        }
+        $this->assertNoDuplicateQueryParameters();
+
+        $sigAlg = $_GET['SigAlg'];
+        if (!array_key_exists($sigAlg, self::REDIRECT_SIGNATURE_ALGOS)) {
+            throw new \Exception("Invalid Response. Signature algorithm " . $sigAlg . " is not accepted");
+        }
+
+        $signed = $this->messageParam . '=' . rawurlencode($_GET[$this->messageParam]);
+        if (isset($_GET['RelayState'])) {
+            $signed .= '&RelayState=' . rawurlencode($_GET['RelayState']);
+        }
+        $signed .= '&SigAlg=' . rawurlencode($sigAlg);
+
+        $signature = base64_decode($_GET['Signature'], true);
+        if ($signature === false) {
+            throw new \Exception("Invalid Response. Malformed Signature on the query string");
+        }
+        $key = @openssl_pkey_get_public($cert);
+        if ($key === false) {
+            throw new \Exception("Invalid Response. The Identity Provider certificate could not be read");
+        }
+        if (openssl_verify($signed, $signature, $key, self::REDIRECT_SIGNATURE_ALGOS[$sigAlg]) !== 1) {
+            throw new \Exception("Invalid Response. Query string signature validation failed");
+        }
+    }
+
+    // PHP keeps only the last occurrence of a repeated query parameter, so a
+    // duplicate would let the signature be verified over a different value than
+    // the one the rest of the code reads.
+    private function assertNoDuplicateQueryParameters()
+    {
+        if (!isset($_SERVER['QUERY_STRING']) || $_SERVER['QUERY_STRING'] === '') {
+            return;
+        }
+        $seen = [];
+        foreach (explode('&', $_SERVER['QUERY_STRING']) as $pair) {
+            if ($pair === '') {
+                continue;
+            }
+            $name = rawurldecode(explode('=', $pair, 2)[0]);
+            if (isset($seen[$name])) {
+                throw new \Exception("Invalid Response. Duplicate " . $name . " parameter on the query string");
+            }
+            $seen[$name] = true;
+        }
     }
 
     // Rejects the response if any identity-bearing element exists outside the

--- a/src/Spid/Saml/In/LogoutRequest.php
+++ b/src/Spid/Saml/In/LogoutRequest.php
@@ -7,7 +7,6 @@ use Italia\Spid\Spid\Saml;
 
 class LogoutRequest implements ResponseInterface
 {
-
     private $saml;
 
     public function __construct(Saml $saml)
@@ -15,9 +14,14 @@ class LogoutRequest implements ResponseInterface
         $this->saml = $saml;
     }
 
-    public function validate($xml, $hasAssertion) : bool
+    public function validate($xml, $assertion) : bool
     {
-        $root = $xml->getElementsByTagName('LogoutRequest')->item(0);
+        $root = $xml->documentElement;
+
+        if (!isset($_SESSION['spidSession']) || !is_array($_SESSION['spidSession'])) {
+            throw new \Exception("Invalid Response. No authenticated session to terminate");
+        }
+        $spidSession = $_SESSION['spidSession'];
 
         if ($xml->getElementsByTagName('Issuer')->length == 0) {
             throw new \Exception("Invalid Response. Missing Issuer element");
@@ -28,40 +32,43 @@ class LogoutRequest implements ResponseInterface
         if ($xml->getElementsByTagName('SessionIndex')->length == 0) {
             throw new \Exception("Invalid Response. Missing SessionIndex element");
         }
-        
-        if ($issuer->getAttribute('Destination') == "") {
-            throw new \Exception("Missing Destination attribute");
-        } elseif ($issuer->getAttribute('Destination') != $this->saml->settings['sp_entityid']) {
-            throw new \Exception("Invalid ForDestinationmat attribute");
-        }
 
         $issuer = $xml->getElementsByTagName('Issuer')->item(0);
         $nameId = $xml->getElementsByTagName('NameID')->item(0);
         $sessionIndex = $xml->getElementsByTagName('SessionIndex')->item(0);
+
+        // Destination belongs to the LogoutRequest root, not to its Issuer: reading
+        // it off the Issuer element meant the attribute was never actually checked.
+        if ($root->getAttribute('Destination') == "") {
+            throw new \Exception("Missing Destination attribute");
+        } elseif ($root->getAttribute('Destination') != $this->saml->settings['sp_entityid']) {
+            throw new \Exception("Invalid Destination attribute, expected " .
+                $this->saml->settings['sp_entityid'] . " but received " . $root->getAttribute('Destination'));
+        }
+
         if ($issuer->getAttribute('Format') == "") {
             throw new \Exception("Missing Format attribute");
         } elseif ($issuer->getAttribute('Format') != "urn:oasis:names:tc:SAML:2.0:nameid-format:entity") {
             throw new \Exception("Invalid Format attribute");
         }
-        if ($issuer->getAttribute('NameQualifier') == "") {
-            throw new \Exception("Missing NameQualifier attribute");
-        } elseif ($issuer->getAttribute('NameQualifier') != $_SESSION['spidSession']->idpEntityID) {
-            throw new \Exception("Invalid NameQualifier attribute");
+        if ($issuer->nodeValue != $spidSession['idpEntityID']) {
+            throw new \Exception("Invalid Issuer, expected " . $spidSession['idpEntityID'] .
+                " but received " . $issuer->nodeValue);
         }
 
         if ($nameId->getAttribute('Format') == "") {
             throw new \Exception("Missing NameID Format attribute");
-        } elseif ($nameId->getAttribute('Format') != "“urn:oasis:names:tc:SAML:2.0:nameidformat:transient") {
+        } elseif ($nameId->getAttribute('Format') != "urn:oasis:names:tc:SAML:2.0:nameid-format:transient") {
             throw new \Exception("Invalid NameID Format attribute");
         }
         if ($nameId->getAttribute('NameQualifier') == "") {
             throw new \Exception("Missing NameID NameQualifier attribute");
-        } elseif ($nameId->getAttribute('NameQualifier') != $_SESSION['spidSession']->idpEntityID) {
+        } elseif ($nameId->getAttribute('NameQualifier') != $spidSession['idpEntityID']) {
             throw new \Exception("Invalid NameID NameQualifier attribute");
         }
-        
-        if ($sessionIndex->nodeValue != $_SESSION['spidSession']->sessionID) {
-            throw new \Exception("Invalid SessionID, expected " . $_SESSION['spidSession']->sessionID .
+
+        if ($sessionIndex->nodeValue != $spidSession['sessionID']) {
+            throw new \Exception("Invalid SessionID, expected " . $spidSession['sessionID'] .
                 " but received " . $sessionIndex->nodeValue);
         }
         $_SESSION['inResponseTo'] = $root->getAttribute('ID');

--- a/src/Spid/Saml/In/LogoutResponse.php
+++ b/src/Spid/Saml/In/LogoutResponse.php
@@ -6,9 +6,9 @@ use Italia\Spid\Spid\Interfaces\ResponseInterface;
 
 class LogoutResponse implements ResponseInterface
 {
-    public function validate($xml, $hasAssertion) : bool
+    public function validate($xml, $assertion) : bool
     {
-        $root = $xml->getElementsByTagName('LogoutResponse')->item(0);
+        $root = $xml->documentElement;
 
         if ($root->getAttribute('ID') == "") {
             throw new \Exception("missing ID attribute");
@@ -37,7 +37,7 @@ class LogoutResponse implements ResponseInterface
             throw new \Exception("Missing Issuer attribute");
         } elseif ($xml->getElementsByTagName('Issuer')->item(0)->nodeValue != $_SESSION['idpEntityId']) {
             throw new \Exception("Invalid Issuer attribute, expected " . $_SESSION['idpEntityId'] .
-                " but received " . $xml->getElementsByTagName('Response')->item(0)->nodeValue);
+                " but received " . $xml->getElementsByTagName('Issuer')->item(0)->nodeValue);
         }
         if ($xml->getElementsByTagName('Status')->length <= 0) {
             throw new \Exception("Missing Status element");
@@ -46,6 +46,9 @@ class LogoutResponse implements ResponseInterface
             // Status code != success
             return false;
         }
+        // The message has been authenticated by BaseResponse before reaching here,
+        // so tearing the session down is a decision taken on verified input.
+        $_SESSION = array();
         session_unset();
         return true;
     }

--- a/src/Spid/Saml/In/Response.php
+++ b/src/Spid/Saml/In/Response.php
@@ -8,6 +8,16 @@ use Italia\Spid\Spid\Saml;
 
 class Response implements ResponseInterface
 {
+    const NS_SAML = 'urn:oasis:names:tc:SAML:2.0:assertion';
+    const NS_SAMLP = 'urn:oasis:names:tc:SAML:2.0:protocol';
+
+    // The only AuthnContextClassRef values a SPID IdP may assert, and the level
+    // each one stands for.
+    const SPID_LEVELS = [
+        'https://www.spid.gov.it/SpidL1' => 1,
+        'https://www.spid.gov.it/SpidL2' => 2,
+        'https://www.spid.gov.it/SpidL3' => 3,
+    ];
 
     private $saml;
 
@@ -16,12 +26,12 @@ class Response implements ResponseInterface
         $this->saml = $saml;
     }
 
-    public function validate($xml, $hasAssertion): bool
+    public function validate($xml, $assertion): bool
     {
         $accepted_clock_skew_seconds = isset($this->saml->settings['accepted_clock_skew_seconds']) ?
             $this->saml->settings['accepted_clock_skew_seconds'] : 0;
 
-        $root = $xml->getElementsByTagName('Response')->item(0);
+        $root = $xml->documentElement;
 
         if ($root->getAttribute('Version') == "") {
             throw new \Exception("Missing Version attribute");
@@ -51,43 +61,47 @@ class Response implements ResponseInterface
                 " but received " . $root->getAttribute('Destination'));
         }
 
-        if ($xml->getElementsByTagName('Issuer')->length == 0) {
+        // The Issuer of the message itself, read as a direct child of the root so
+        // that no nested copy can be mistaken for it.
+        $responseIssuer = $this->query($root, './saml:Issuer')->item(0);
+        if (is_null($responseIssuer)) {
             throw new \Exception("Missing Issuer attribute");
-            //check item 0, this the Issuer element child of Response
-        } elseif ($xml->getElementsByTagName('Issuer')->item(0)->nodeValue != $_SESSION['idpEntityId']) {
+        } elseif ($responseIssuer->nodeValue != $_SESSION['idpEntityId']) {
             throw new \Exception("Invalid Issuer attribute, expected " . $_SESSION['idpEntityId'] .
-                " but received " . $xml->getElementsByTagName('Issuer')->item(0)->nodeValue);
-        } elseif ($xml->getElementsByTagName('Issuer')->item(0)->getAttribute('Format') !=
+                " but received " . $responseIssuer->nodeValue);
+        } elseif ($responseIssuer->getAttribute('Format') !=
             'urn:oasis:names:tc:SAML:2.0:nameid-format:entity') {
             throw new \Exception("Invalid Issuer attribute, expected 'urn:oasis:names:tc:SAML:2.0:nameid-format:" .
-                "entity'" . " but received " . $xml->getElementsByTagName('Issuer')->item(0)->getAttribute('Format'));
+                "entity'" . " but received " . $responseIssuer->getAttribute('Format'));
         }
 
-        if ($hasAssertion) {
-            if ($xml->getElementsByTagName('Assertion')->item(0)->getAttribute('ID') == "" ||
-                $xml->getElementsByTagName('Assertion')->item(0)->getAttribute('ID') == null) {
+        if (!is_null($assertion)) {
+            if ($assertion->getAttribute('ID') == "" ||
+                $assertion->getAttribute('ID') == null) {
                 throw new \Exception("Missing ID attribute on Assertion");
-            } elseif ($xml->getElementsByTagName('Assertion')->item(0)->getAttribute('Version') != '2.0') {
+            } elseif ($assertion->getAttribute('Version') != '2.0') {
                 throw new \Exception("Invalid Version attribute on Assertion");
-            } elseif ($xml->getElementsByTagName('Assertion')->item(0)->getAttribute('IssueInstant') == "") {
+            } elseif ($assertion->getAttribute('IssueInstant') == "") {
                 throw new \Exception("Invalid IssueInstant attribute on Assertion");
-            } elseif (!$this->validateDate(
-                $xml->getElementsByTagName('Assertion')->item(0)->getAttribute('IssueInstant')
-            )) {
+            } elseif (!$this->validateDate($assertion->getAttribute('IssueInstant'))) {
                 throw new \Exception("Invalid IssueInstant attribute on Assertion");
-            } elseif (strtotime($xml->getElementsByTagName('Assertion')->item(0)->getAttribute('IssueInstant')) >
+            } elseif (strtotime($assertion->getAttribute('IssueInstant')) >
                 strtotime('now') + $accepted_clock_skew_seconds) {
                 throw new \Exception("IssueInstant attribute on Assertion is in the future");
             }
 
-            // check item 1, this must be the Issuer element child of Assertion
-            if ($hasAssertion && $xml->getElementsByTagName('Issuer')->item(1)->nodeValue != $_SESSION['idpEntityId']) {
+            // The Issuer of the assertion, again as a direct child of the element
+            // it belongs to rather than by position in a document wide list.
+            $assertionIssuer = $this->query($assertion, './saml:Issuer')->item(0);
+            if (is_null($assertionIssuer)) {
+                throw new \Exception("Missing Issuer element on Assertion");
+            } elseif ($assertionIssuer->nodeValue != $_SESSION['idpEntityId']) {
                 throw new \Exception("Invalid Issuer attribute, expected " . $_SESSION['idpEntityId'] .
-                    " but received " . $xml->getElementsByTagName('Issuer')->item(1)->nodeValue);
-            } elseif ($xml->getElementsByTagName('Issuer')->item(1)->getAttribute('Format') !=
+                    " but received " . $assertionIssuer->nodeValue);
+            } elseif ($assertionIssuer->getAttribute('Format') !=
                 'urn:oasis:names:tc:SAML:2.0:nameid-format:entity') {
                 throw new \Exception("Invalid Issuer attribute, expected 'urn:oasis:names:tc:SAML:2.0:nameid-format:" .
-                "entity'" . " but received " . $xml->getElementsByTagName('Issuer')->item(1)->getAttribute('Format'));
+                "entity'" . " but received " . $assertionIssuer->getAttribute('Format'));
             }
 
             if ($xml->getElementsByTagName('Conditions')->length == 0) {
@@ -177,7 +191,12 @@ class Response implements ResponseInterface
             throw new \Exception("Missing StatusCode element");
         } elseif ($xml->getElementsByTagName('StatusCode')->item(0)->getAttribute('Value') ==
             'urn:oasis:names:tc:SAML:2.0:status:Success') {
-            if ($hasAssertion && $xml->getElementsByTagName('AuthnStatement')->length <= 0) {
+            // A successful Response always carries a validated assertion: BaseResponse
+            // refuses one that does not, so reaching here without it is impossible.
+            if (is_null($assertion)) {
+                throw new \Exception("Missing Assertion element");
+            }
+            if ($xml->getElementsByTagName('AuthnStatement')->length <= 0) {
                 throw new \Exception("Missing AuthnStatement element");
             }
         } elseif ($xml->getElementsByTagName('StatusCode')->item(0)->getAttribute('Value') !=
@@ -197,12 +216,23 @@ class Response implements ResponseInterface
         }
 
         // Response OK
-        $session = $this->spidSession($xml);
+        $level = $this->validateLevel($assertion);
+        $session = $this->spidSession($assertion, $level);
+
+        // Session fixation: the identifier used while unauthenticated must not
+        // carry over into the authenticated session. Regenerating it before the
+        // authenticated state is written means the old identifier never holds it.
+        if (session_status() === PHP_SESSION_ACTIVE && !headers_sent()) {
+            session_regenerate_id(true);
+        }
+
         $_SESSION['spidSession'] = (array)$session;
         unset($_SESSION['RequestID']);
         unset($_SESSION['idpName']);
         unset($_SESSION['idpEntityId']);
         unset($_SESSION['acsUrl']);
+        unset($_SESSION['requestedLevel']);
+        unset($_SESSION['requestedComparison']);
         return true;
     }
 
@@ -222,26 +252,89 @@ class Response implements ResponseInterface
         }
     }
 
-    private function spidSession(\DOMDocument $xml)
+    // The level the IdP actually asserted has to be a real SPID level, and it has
+    // to satisfy the level the SP asked for. Deriving it from the last character of
+    // the AuthnContextClassRef accepted any URI that happened to end with the right
+    // digit, and the value was never compared with the requested level at all, so
+    // an IdP could answer SpidL1 to a request for SpidL2 and be believed.
+    private function validateLevel(\DOMElement $assertion) : int
+    {
+        $refs = $this->query($assertion, './saml:AuthnStatement/saml:AuthnContext/saml:AuthnContextClassRef');
+        if ($refs->length != 1) {
+            throw new \Exception("Invalid Response. Exactly one AuthnContextClassRef is required, found " .
+                $refs->length);
+        }
+        $uri = trim($refs->item(0)->nodeValue);
+        if (!array_key_exists($uri, self::SPID_LEVELS)) {
+            throw new \Exception("Invalid Response. Unknown AuthnContextClassRef " . $uri);
+        }
+        $returned = self::SPID_LEVELS[$uri];
+
+        if (!isset($_SESSION['requestedLevel'])) {
+            // No requested level was recorded for this transaction, so the session
+            // was not opened through this library's login(). The asserted URI has
+            // still been checked against the allowed set; there is simply nothing
+            // to compare it against.
+            return $returned;
+        }
+        $requested = (int)$_SESSION['requestedLevel'];
+        $comparison = $_SESSION['requestedComparison'] ?? 'exact';
+        if (!$this->levelSatisfies($returned, $requested, $comparison)) {
+            throw new \Exception("Invalid Response. The Identity Provider returned SPID level " . $returned .
+                ", which does not satisfy the requested level " . $requested .
+                " with comparison " . $comparison);
+        }
+        return $returned;
+    }
+
+    // SAML 2.0 core, RequestedAuthnContext/@Comparison semantics.
+    private function levelSatisfies(int $returned, int $requested, string $comparison) : bool
+    {
+        switch ($comparison) {
+            case 'minimum':
+                return $returned >= $requested;
+            case 'better':
+                return $returned > $requested;
+            case 'maximum':
+                return $returned <= $requested;
+            case 'exact':
+            default:
+                return $returned === $requested;
+        }
+    }
+
+    // Builds the authenticated session out of the validated assertion only. Reading
+    // the whole document here is what made a forged element planted outside the
+    // assertion end up in the session.
+    private function spidSession(\DOMElement $assertion, int $level)
     {
         $session = new Session();
 
         $attributes = array();
-        $attributeStatements = $xml->getElementsByTagName('AttributeStatement');
-
-        if ($attributeStatements->length > 0) {
-            foreach ($attributeStatements->item(0)->childNodes as $attr) {
-                if ($attr->hasAttributes()) {
-                    $attributes[$attr->attributes->getNamedItem('Name')->value] = trim($attr->nodeValue);
-                }
+        foreach ($this->query($assertion, './saml:AttributeStatement/saml:Attribute') as $attr) {
+            $name = $attr->getAttribute('Name');
+            if ($name === '') {
+                continue;
             }
+            $attributes[$name] = trim($attr->nodeValue);
         }
 
         $session->sessionID = $_SESSION['RequestID'];
         $session->idp = $_SESSION['idpName'];
-        $session->idpEntityID = $xml->getElementsByTagName('Issuer')->item(0)->nodeValue;
+        // Validated above against the Issuer of both the message and the assertion.
+        $session->idpEntityID = $_SESSION['idpEntityId'];
         $session->attributes = $attributes;
-        $session->level = substr($xml->getElementsByTagName('AuthnContextClassRef')->item(0)->nodeValue, -1);
+        $session->level = $level;
         return $session;
+    }
+
+    // Namespace aware lookup, evaluated relative to $context so that a result can
+    // only ever come from inside the element it is meant to describe.
+    private function query(\DOMElement $context, string $path)
+    {
+        $xpath = new \DOMXPath($context->ownerDocument);
+        $xpath->registerNamespace('saml', self::NS_SAML);
+        $xpath->registerNamespace('samlp', self::NS_SAMLP);
+        return $xpath->query($path, $context);
     }
 }

--- a/src/Spid/Saml/Out/Base.php
+++ b/src/Spid/Saml/Out/Base.php
@@ -56,6 +56,12 @@ class Base
             $_SERVER['HTTPS'] === 'on' ? "https" : "http") .
             "//{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}" : $redirectTo;
         $relayState = null;
+        // Everything interpolated below lands inside an HTML attribute, so it is
+        // escaped for that context: the action URL comes from Identity Provider
+        // metadata and must not be able to close the attribute and inject markup.
+        $url = htmlspecialchars($url, ENT_QUOTES);
+        $SAMLRequest = htmlspecialchars($SAMLRequest, ENT_QUOTES);
+        $relayState = htmlspecialchars((string) $relayState, ENT_QUOTES);
         return <<<HTML
 <html>
     <body onload="javascript:document.forms[0].submit()">

--- a/src/Spid/Saml/SignatureUtils.php
+++ b/src/Spid/Saml/SignatureUtils.php
@@ -81,7 +81,11 @@ class SignatureUtils
     public static function validateXmlSignature($xml, $cert) : bool
     {
         if (is_null($xml)) {
-            return true;
+            // An absent signature is never a verified one. Which messages need a
+            // signature is decided by the caller, per message type; turning a
+            // missing signature into a successful verification here is what let a
+            // response simply omit its signature to skip the check altogether.
+            return false;
         }
 
         $signedNode = $xml->parentNode;

--- a/tests/IdpMetadataTest.php
+++ b/tests/IdpMetadataTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+use Italia\Spid\Spid\Saml;
+use Italia\Spid\Spid\Saml\Idp;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/SamlFixture.php';
+
+/**
+ * Regression tests for the arbitrary Identity Provider metadata loading reported
+ * against f5899ebcac646506c80a078fa2f415ed59605952.
+ *
+ * Idp::loadFromXml() used the caller supplied value as a file name as soon as it
+ * contained the configured metadata folder anywhere inside it, and then handed it
+ * to file_exists()/simplexml_load_file(). Since the X.509 certificate found in
+ * that metadata is the trust anchor used to validate the SAML Response, choosing
+ * the file means choosing who may authenticate users.
+ */
+final class IdpMetadataTest extends TestCase
+{
+    /** @var SamlFixture */
+    private static $f;
+    /** @var Saml */
+    private static $saml;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$f = new SamlFixture('spid_idp_metadata');
+        self::$saml = new Saml(self::$f->settings, false);
+
+        // A rogue metadata file, with the attacker's own certificate, reachable on
+        // the filesystem but outside the configured folder.
+        $rogue = SamlFixture::keyPair('rogue.example.com');
+        file_put_contents(self::$f->dir . '/rogue.xml', self::$f->metadataFor($rogue['cert']));
+        // ... and one whose path contains the metadata folder name as a substring,
+        // which is exactly what the old check tested for.
+        @mkdir(self::$f->dir . '/idp_metadata_evil');
+        file_put_contents(
+            self::$f->dir . '/idp_metadata_evil/idp.xml',
+            self::$f->metadataFor($rogue['cert'])
+        );
+        @symlink(self::$f->dir . '/rogue.xml', self::$f->dir . '/idp_metadata/linked.xml');
+        @mkdir(self::$f->dir . '/idp_metadata/directory.xml');
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::$f->cleanUp();
+    }
+
+    private function load(string $value): Idp
+    {
+        $idp = new Idp(self::$saml);
+        return $idp->loadFromXml($value);
+    }
+
+    public function testBareIdentifierIsAccepted(): void
+    {
+        $idp = $this->load('idp');
+        $this->assertSame('idp', $idp->idpFileName);
+        $this->assertSame(self::$f->idpEntityId, $idp->metadata['idpEntityId']);
+    }
+
+    public function testIdentifierWithExtensionIsAccepted(): void
+    {
+        $this->assertSame('idp', $this->load('idp.xml')->idpFileName);
+    }
+
+    // getIdpList() enumerates the folder with glob() and passes full paths.
+    public function testPathInsideTheConfiguredFolderIsAccepted(): void
+    {
+        $idp = $this->load(self::$f->dir . '/idp_metadata/idp.xml');
+        $this->assertSame('idp', $idp->idpFileName, 'the session must hold the identifier, not the path');
+    }
+
+    /**
+     * @dataProvider rejectedValues
+     */
+    public function testRejectedValues(string $value): void
+    {
+        $this->expectException(\Exception::class);
+        $this->load($value);
+    }
+
+    public function rejectedValues(): array
+    {
+        // The folder the tests configure; used to build the values whose path
+        // contains it literally, the case the old substring check accepted.
+        $folder = sys_get_temp_dir() . '/spid_idp_metadata_' . getmypid() . '/idp_metadata/';
+
+        return [
+            'unknown identifier' => ['not-a-configured-idp'],
+            'empty' => [''],
+            'traversal' => ['../rogue'],
+            'traversal with extension' => ['../rogue.xml'],
+            'traversal through the folder' => [$folder . '../rogue.xml'],
+            'deep traversal' => [$folder . '../../../../etc/passwd'],
+            'absolute path outside' => ['/etc/passwd'],
+            'windows style path' => ['C:\\Windows\\Temp\\rogue.xml'],
+            'sibling folder with matching prefix' => [$folder . '_evil/idp.xml'],
+            'file scheme' => ['file://' . $folder . 'idp.xml'],
+            'ftp scheme' => ['ftp://attacker.example' . $folder . 'idp.xml'],
+            'http scheme' => ['http://attacker.example' . $folder . 'idp.xml'],
+            'https scheme' => ['https://attacker.example' . $folder . 'idp.xml'],
+            'php filter wrapper' => ['php://filter/resource=' . $folder . 'idp.xml'],
+            'data wrapper' => ['data://text/plain;base64,PG1kOkVudGl0eURlc2NyaXB0b3I+'],
+            'phar wrapper' => ['phar://' . $folder . 'rogue.phar/idp.xml'],
+            'symlink out of the folder' => ['linked'],
+            'directory named like a metadata file' => ['directory'],
+            'nul byte' => ["idp\0.xml"],
+        ];
+    }
+
+    // The certificate actually used to validate a Response must be the one of the
+    // Identity Provider the server selected, never one supplied through the
+    // parameter used to pick it.
+    public function testTheTrustAnchorAlwaysComesFromTheConfiguredFolder(): void
+    {
+        $expected = file_get_contents(self::$f->idpCert);
+        $loaded = $this->load('idp')->metadata['idpCertValue'];
+
+        $normalize = function ($pem) {
+            return preg_replace('/\s+/', '', $pem);
+        };
+        $this->assertSame($normalize($expected), $normalize($loaded));
+    }
+}

--- a/tests/LogoutSecurityTest.php
+++ b/tests/LogoutSecurityTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/SamlFixture.php';
+
+/**
+ * Regression tests for the incomplete integrity verification of the logout
+ * messages reported against f5899ebcac646506c80a078fa2f415ed59605952.
+ *
+ * A LogoutResponse carrying no signature at all reached the end of validation and
+ * terminated the session as long as the attacker knew the correlation values, and
+ * the HTTP-Redirect binding never verified the SigAlg/Signature pair it receives.
+ * An Identity Provider initiated LogoutRequest was unreachable through its normal
+ * SAMLRequest parameter, and its validation used a variable before assigning it.
+ */
+final class LogoutSecurityTest extends TestCase
+{
+    /** @var SamlFixture */
+    private static $f;
+    private static $rogueKey;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$f = new SamlFixture('spid_logout_sec');
+        $rogue = SamlFixture::keyPair('rogue.example.com');
+        self::$rogueKey = self::$f->dir . '/rogue.key';
+        file_put_contents(self::$rogueKey, $rogue['key']);
+
+        if (session_status() === PHP_SESSION_NONE) {
+            @session_start();
+        }
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::$f->cleanUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+        $_GET = [];
+        unset($_POST['SAMLResponse'], $_POST['SAMLRequest'], $_SERVER['QUERY_STRING']);
+    }
+
+    // Session as it is right after the SP sent its LogoutRequest.
+    private function logoutSession(): array
+    {
+        return [
+            'idpName' => 'idp',
+            'RequestID' => self::$f->requestId,
+            'sloUrl' => self::$f->sloUrl,
+            'idpEntityId' => self::$f->idpEntityId,
+            'spidSession' => [
+                'sessionID' => self::$f->requestId,
+                'idp' => 'idp',
+                'idpEntityID' => self::$f->idpEntityId,
+                'level' => 2,
+                'attributes' => ['fiscalNumber' => 'REAL-USER-FISCAL-CODE'],
+            ],
+        ];
+    }
+
+    // -----------------------------------------------------------------
+    // POST binding: the XML signature is what authenticates the message.
+    // -----------------------------------------------------------------
+    public function testSignedLogoutResponseTerminatesTheSession(): void
+    {
+        $signed = self::$f->sign(self::$f->logoutResponse());
+
+        $this->assertFalse(self::$f->post($this->logoutSession(), $signed));
+        $this->assertArrayNotHasKey('spidSession', $_SESSION, 'the session must be gone after a logout');
+    }
+
+    public function testUnsignedLogoutResponseIsRejected(): void
+    {
+        $this->expectException(\Exception::class);
+        try {
+            self::$f->post($this->logoutSession(), self::$f->logoutResponse());
+        } catch (\Exception $e) {
+            $this->assertArrayHasKey(
+                'spidSession',
+                $_SESSION,
+                'an unauthenticated logout must not touch the session'
+            );
+            throw $e;
+        }
+    }
+
+    public function testLogoutResponseSignedByAnotherKeyIsRejected(): void
+    {
+        $rogueCert = self::$f->dir . '/rogue.crt';
+        $kp = SamlFixture::keyPair('rogue2.example.com');
+        file_put_contents(self::$f->dir . '/rogue2.key', $kp['key']);
+        file_put_contents($rogueCert, $kp['cert']);
+
+        $signed = self::$f->sign(
+            self::$f->logoutResponse(),
+            self::$f->dir . '/rogue2.key',
+            $rogueCert
+        );
+
+        $this->expectException(\Exception::class);
+        self::$f->post($this->logoutSession(), $signed);
+    }
+
+    // -----------------------------------------------------------------
+    // Redirect binding: the signature covers the query string.
+    // -----------------------------------------------------------------
+    public function testRedirectLogoutResponseWithValidQuerySignatureIsAccepted(): void
+    {
+        $this->assertFalse(self::$f->redirect(
+            $this->logoutSession(),
+            self::$f->logoutResponse(),
+            'SAMLResponse',
+            self::$f->idpKey
+        ));
+        $this->assertArrayNotHasKey('spidSession', $_SESSION);
+    }
+
+    public function testRedirectLogoutResponseWithoutSignatureIsRejected(): void
+    {
+        $this->expectException(\Exception::class);
+        self::$f->redirect($this->logoutSession(), self::$f->logoutResponse());
+    }
+
+    public function testRedirectLogoutResponseSignedByAnotherKeyIsRejected(): void
+    {
+        $this->expectException(\Exception::class);
+        self::$f->redirect(
+            $this->logoutSession(),
+            self::$f->logoutResponse(),
+            'SAMLResponse',
+            self::$rogueKey
+        );
+    }
+
+    public function testRedirectLogoutResponseWithDisallowedAlgorithmIsRejected(): void
+    {
+        $this->expectException(\Exception::class);
+        self::$f->redirect(
+            $this->logoutSession(),
+            self::$f->logoutResponse(),
+            'SAMLResponse',
+            self::$f->idpKey,
+            ['SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1']
+        );
+    }
+
+    public function testRedirectLogoutResponseWithAlteredSignatureIsRejected(): void
+    {
+        $this->expectException(\Exception::class);
+        self::$f->redirect(
+            $this->logoutSession(),
+            self::$f->logoutResponse(),
+            'SAMLResponse',
+            self::$f->idpKey,
+            ['Signature' => base64_encode('not a signature')]
+        );
+    }
+
+    public function testRedirectLogoutResponseWithDuplicateParametersIsRejected(): void
+    {
+        $this->expectException(\Exception::class);
+        self::$f->redirect(
+            $this->logoutSession(),
+            self::$f->logoutResponse(),
+            'SAMLResponse',
+            self::$f->idpKey,
+            ['QUERY_STRING' => 'SAMLResponse=a&SAMLResponse=b&SigAlg=x&Signature=y']
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Identity Provider initiated logout, which arrives in SAMLRequest.
+    // -----------------------------------------------------------------
+    public function testSignedLogoutRequestOnSamlRequestIsProcessed(): void
+    {
+        $signed = self::$f->sign(self::$f->logoutRequest());
+
+        // isAuthenticated() answers false and the library replies to the Identity
+        // Provider with its own LogoutResponse, clearing the local session.
+        $this->assertFalse(self::$f->post($this->logoutSession(), $signed, 'SAMLRequest'));
+        $this->assertArrayNotHasKey('spidSession', $_SESSION);
+    }
+
+    public function testUnsignedLogoutRequestIsRejected(): void
+    {
+        $this->expectException(\Exception::class);
+        try {
+            self::$f->post($this->logoutSession(), self::$f->logoutRequest(), 'SAMLRequest');
+        } catch (\Exception $e) {
+            $this->assertArrayHasKey('spidSession', $_SESSION);
+            throw $e;
+        }
+    }
+
+    public function testLogoutRequestForAnotherSessionIsRejected(): void
+    {
+        $signed = self::$f->sign(self::$f->logoutRequest(['sessionIndex' => '_someone-elses-session']));
+
+        $this->expectException(\Exception::class);
+        self::$f->post($this->logoutSession(), $signed, 'SAMLRequest');
+    }
+
+    public function testLogoutRequestWithWrongDestinationIsRejected(): void
+    {
+        $signed = self::$f->sign(self::$f->logoutRequest(['destination' => 'https://attacker.example/']));
+
+        $this->expectException(\Exception::class);
+        self::$f->post($this->logoutSession(), $signed, 'SAMLRequest');
+    }
+
+    // A Response must not be accepted through the parameter reserved for requests.
+    public function testResponseOnSamlRequestIsRejected(): void
+    {
+        $response = self::$f->response(self::$f->signedAssertion());
+
+        $this->expectException(\Exception::class);
+        self::$f->post($this->logoutSession(), $response, 'SAMLRequest');
+    }
+}

--- a/tests/ResponseSecurityTest.php
+++ b/tests/ResponseSecurityTest.php
@@ -268,6 +268,23 @@ final class ResponseSecurityTest extends TestCase
         self::$f->post($this->session(['requestedLevel' => 2, 'requestedComparison' => 'maximum']), $response);
     }
 
+    /**
+     * @dataProvider undefinedLevels
+     */
+    public function testAuthnRequestRefusesAnUndefinedLevel($level): void
+    {
+        $saml = new Italia\Spid\Spid\Saml(self::$f->settings, false);
+        $idp = $saml->loadIdpFromFile('idp');
+
+        $this->expectException(\Exception::class);
+        $idp->authnRequest(0, null, Italia\Spid\Spid\Saml\Settings::BINDING_POST, $level, null, false);
+    }
+
+    public function undefinedLevels(): array
+    {
+        return [[0], [4], [-1], ['2; DROP'], ['']];
+    }
+
     // -----------------------------------------------------------------
     // Session fixation: the pre-login identifier must not carry the
     // authenticated state.

--- a/tests/ResponseSecurityTest.php
+++ b/tests/ResponseSecurityTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+use Italia\Spid\Spid\Saml\SignatureUtils;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/SamlFixture.php';
+
+/**
+ * Regression tests for the authentication bypass reported against
+ * f5899ebcac646506c80a078fa2f415ed59605952, plus the SPID level and session
+ * fixation weaknesses found alongside it.
+ *
+ * The bypass: the library required a signature only when the response happened to
+ * contain an Assertion, so a Response with StatusCode=Success carrying no
+ * Assertion and no signature at all skipped every identity check, and the session
+ * was then built from elements read anywhere in the unsigned document. No SPID
+ * identity, no assertion, no key material were needed (CWE-347, CWE-290).
+ */
+final class ResponseSecurityTest extends TestCase
+{
+    /** @var SamlFixture */
+    private static $f;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$f = new SamlFixture('spid_response_sec');
+        // Start the session up front so populating $_SESSION in the individual
+        // tests is not wiped by the session_start() the first Sp would trigger.
+        if (session_status() === PHP_SESSION_NONE) {
+            @session_start();
+        }
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::$f->cleanUp();
+    }
+
+    protected function tearDown(): void
+    {
+        // Do not leak session or request state into the other test classes.
+        $_SESSION = [];
+        $_GET = [];
+        unset($_POST['SAMLResponse'], $_POST['SAMLRequest']);
+    }
+
+    private function session(array $overrides = []): array
+    {
+        return self::$f->loginSession(array_merge([
+            'requestedLevel' => 2,
+            'requestedComparison' => 'exact',
+        ], $overrides));
+    }
+
+    // -----------------------------------------------------------------
+    // Baseline: the honest response still works.
+    // -----------------------------------------------------------------
+    public function testGenuineSignedResponseIsAccepted(): void
+    {
+        $response = self::$f->response(self::$f->signedAssertion());
+
+        $this->assertTrue(self::$f->post($this->session(), $response));
+        $this->assertSame(
+            'REAL-USER-FISCAL-CODE',
+            $_SESSION['spidSession']['attributes']['fiscalNumber'],
+            'The session must carry the attributes of the signed assertion'
+        );
+        $this->assertSame(2, $_SESSION['spidSession']['level']);
+    }
+
+    // -----------------------------------------------------------------
+    // The reported bypass, in the exact shape of the report's PoC.
+    // -----------------------------------------------------------------
+    public function testSuccessResponseWithoutAssertionIsRejected(): void
+    {
+        $forged = self::$f->response(
+            '<saml:AttributeStatement>'
+            . '<saml:Attribute Name="fiscalNumber">'
+            . '<saml:AttributeValue>ATTACKER-OWNED</saml:AttributeValue></saml:Attribute>'
+            . '</saml:AttributeStatement>'
+            . '<saml:AuthnContextClassRef>https://www.spid.gov.it/SpidL3</saml:AuthnContextClassRef>'
+        );
+
+        $this->expectException(\Exception::class);
+        try {
+            self::$f->post($this->session(), $forged);
+        } catch (\Exception $e) {
+            $this->assertArrayNotHasKey(
+                'spidSession',
+                $_SESSION,
+                'A response with no assertion must never produce a session'
+            );
+            throw $e;
+        }
+    }
+
+    public function testSuccessResponseWithUnsignedAssertionIsRejected(): void
+    {
+        $response = self::$f->response(self::$f->assertionXml(['fiscalNumber' => 'ATTACKER-OWNED']));
+
+        $this->expectException(\Exception::class);
+        self::$f->post($this->session(), $response);
+    }
+
+    // A signature on the Response root does not stand in for the assertion
+    // signature: the policy requires the assertion itself to be signed.
+    public function testResponseSignedOnlyOnTheRootIsRejected(): void
+    {
+        $response = self::$f->sign(
+            self::$f->response(self::$f->assertionXml(['fiscalNumber' => 'ATTACKER-OWNED']))
+        );
+
+        $this->expectException(\Exception::class);
+        self::$f->post($this->session(), $response);
+    }
+
+    // -----------------------------------------------------------------
+    // Failure responses: no assertion is expected, and no session may appear.
+    // -----------------------------------------------------------------
+    public function testErrorResponseWithoutAssertionCreatesNoSession(): void
+    {
+        $response = self::$f->response('', ['status' => 'urn:oasis:names:tc:SAML:2.0:status:Requester']);
+
+        try {
+            self::$f->post($this->session(), $response);
+            $this->fail('A non successful response must be refused');
+        } catch (\Exception $e) {
+            $this->assertStringContainsString('StatusCode is not Success', $e->getMessage());
+        }
+        $this->assertArrayNotHasKey('spidSession', $_SESSION);
+    }
+
+    public function testErrorResponseCarryingAnAssertionIsRejected(): void
+    {
+        $response = self::$f->response(
+            self::$f->signedAssertion(),
+            ['status' => 'urn:oasis:names:tc:SAML:2.0:status:Requester']
+        );
+
+        $this->expectException(\Exception::class);
+        self::$f->post($this->session(), $response);
+    }
+
+    // -----------------------------------------------------------------
+    // Wrapping variants that must stay closed.
+    // -----------------------------------------------------------------
+    public function testHomonymElementInForeignNamespaceIsRejected(): void
+    {
+        // Same local name, different namespace, placed outside the assertion:
+        // getElementsByTagName() ignores the namespace, so item(0) could pick it.
+        $response = self::$f->response(
+            '<evil:AttributeStatement xmlns:evil="urn:attacker">'
+            . '<evil:Attribute Name="fiscalNumber">'
+            . '<evil:AttributeValue>ATTACKER-OWNED</evil:AttributeValue></evil:Attribute>'
+            . '</evil:AttributeStatement>'
+            . self::$f->signedAssertion()
+        );
+
+        $this->expectException(\Exception::class);
+        self::$f->post($this->session(), $response);
+    }
+
+    public function testNestedResponseInsideAnEnvelopeIsRejected(): void
+    {
+        $inner = self::$f->response(self::$f->signedAssertion());
+        $enveloped = '<wrapper xmlns="urn:attacker">'
+            . preg_replace('/^<\?xml[^>]*\?>\s*/', '', $inner)
+            . '</wrapper>';
+
+        $this->expectException(\Exception::class);
+        self::$f->post($this->session(), $enveloped);
+    }
+
+    public function testTwoAssertionsAreRejected(): void
+    {
+        $response = self::$f->response(
+            self::$f->signedAssertion() .
+            self::$f->signedAssertion(['assertionId' => '_second', 'fiscalNumber' => 'ATTACKER-OWNED'])
+        );
+
+        $this->expectException(\Exception::class);
+        self::$f->post($this->session(), $response);
+    }
+
+    // -----------------------------------------------------------------
+    // An absent signature must never read as a verified one.
+    // -----------------------------------------------------------------
+    public function testValidateXmlSignatureRefusesAnAbsentSignature(): void
+    {
+        $this->assertFalse(
+            SignatureUtils::validateXmlSignature(null, file_get_contents(self::$f->idpCert)),
+            'A null signature node must not validate'
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // SPID level: the asserted level must be a real one and must satisfy the
+    // level the Service Provider asked for.
+    // -----------------------------------------------------------------
+    public function testLowerLevelThanRequestedIsRejected(): void
+    {
+        $response = self::$f->response(
+            self::$f->signedAssertion(['authnContextClassRef' => 'https://www.spid.gov.it/SpidL1'])
+        );
+
+        $this->expectException(\Exception::class);
+        self::$f->post($this->session(['requestedLevel' => 2]), $response);
+    }
+
+    public function testLevel2AgainstRequestedLevel3IsRejected(): void
+    {
+        $response = self::$f->response(self::$f->signedAssertion());
+
+        $this->expectException(\Exception::class);
+        self::$f->post($this->session(['requestedLevel' => 3]), $response);
+    }
+
+    public function testUnknownAuthnContextClassRefEndingInTheRightDigitIsRejected(): void
+    {
+        $response = self::$f->response(
+            self::$f->signedAssertion(['authnContextClassRef' => 'https://attacker.example/SpidL2'])
+        );
+
+        $this->expectException(\Exception::class);
+        self::$f->post($this->session(), $response);
+    }
+
+    public function testMultipleAuthnContextClassRefIsRejected(): void
+    {
+        $response = self::$f->response(self::$f->signedAssertion([
+            'extraAuthnContextClassRef' =>
+                '<saml:AuthnContextClassRef>https://www.spid.gov.it/SpidL3</saml:AuthnContextClassRef>',
+        ]));
+
+        $this->expectException(\Exception::class);
+        self::$f->post($this->session(['requestedLevel' => 3]), $response);
+    }
+
+    public function testMinimumComparisonAcceptsAHigherLevel(): void
+    {
+        $response = self::$f->response(
+            self::$f->signedAssertion(['authnContextClassRef' => 'https://www.spid.gov.it/SpidL3'])
+        );
+
+        $this->assertTrue(
+            self::$f->post($this->session(['requestedLevel' => 2, 'requestedComparison' => 'minimum']), $response)
+        );
+        $this->assertSame(3, $_SESSION['spidSession']['level']);
+    }
+
+    public function testBetterComparisonRejectsAnEqualLevel(): void
+    {
+        $response = self::$f->response(self::$f->signedAssertion());
+
+        $this->expectException(\Exception::class);
+        self::$f->post($this->session(['requestedLevel' => 2, 'requestedComparison' => 'better']), $response);
+    }
+
+    public function testMaximumComparisonRejectsAHigherLevel(): void
+    {
+        $response = self::$f->response(
+            self::$f->signedAssertion(['authnContextClassRef' => 'https://www.spid.gov.it/SpidL3'])
+        );
+
+        $this->expectException(\Exception::class);
+        self::$f->post($this->session(['requestedLevel' => 2, 'requestedComparison' => 'maximum']), $response);
+    }
+
+    // -----------------------------------------------------------------
+    // Session fixation: the pre-login identifier must not carry the
+    // authenticated state.
+    // -----------------------------------------------------------------
+    public function testSessionIdIsRegeneratedOnLogin(): void
+    {
+        $response = self::$f->response(self::$f->signedAssertion());
+
+        $before = session_id();
+        $this->assertNotSame('', $before, 'the test needs an active session');
+
+        $this->assertTrue(self::$f->post($this->session(), $response));
+
+        $this->assertNotSame($before, session_id(), 'the session id must change when the login completes');
+        $this->assertArrayHasKey('spidSession', $_SESSION);
+    }
+}

--- a/tests/SamlFixture.php
+++ b/tests/SamlFixture.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+use Italia\Spid\Spid\Saml\SignatureUtils;
+
+/**
+ * Shared fixture for the security regression tests: a throwaway Identity Provider
+ * with its own key pair and metadata, plus builders for the SAML messages the
+ * tests need to forge.
+ *
+ * Not a test case, and deliberately not named *Test.php so PHPUnit does not try
+ * to collect it. Test files pull it in with require_once.
+ */
+class SamlFixture
+{
+    public $dir;
+    public $idpKey;
+    public $idpCert;
+    public $settings;
+
+    public $idpEntityId = 'https://idp.example.com/';
+    public $spEntityId = 'https://sp.example.com/';
+    public $acsUrl = 'https://sp.example.com/acs';
+    public $sloUrl = 'https://sp.example.com/slo';
+    public $requestId = '_request0123456789abcdef';
+
+    public function __construct(string $prefix)
+    {
+        $this->dir = sys_get_temp_dir() . '/' . $prefix . '_' . getmypid();
+        @mkdir($this->dir);
+        @mkdir($this->dir . '/idp_metadata');
+
+        $kc = self::keyPair('idp.example.com');
+        $this->idpKey = $this->dir . '/idp.key';
+        $this->idpCert = $this->dir . '/idp.crt';
+        file_put_contents($this->idpKey, $kc['key']);
+        file_put_contents($this->idpCert, $kc['cert']);
+
+        file_put_contents(
+            $this->dir . '/idp_metadata/idp.xml',
+            $this->metadataFor($kc['cert'])
+        );
+
+        // A real Service Provider key pair, so the outgoing messages the library
+        // builds during a logout round trip can actually be signed.
+        $sp = self::keyPair('sp.example.com');
+        file_put_contents($this->dir . '/sp.key', $sp['key']);
+        file_put_contents($this->dir . '/sp.crt', $sp['cert']);
+
+        $this->settings = [
+            'sp_entityid' => $this->spEntityId,
+            'sp_key_file' => $this->dir . '/sp.key',
+            'sp_cert_file' => $this->dir . '/sp.crt',
+            'sp_assertionconsumerservice' => [$this->acsUrl],
+            'sp_singlelogoutservice' => [[$this->sloUrl, '']],
+            'idp_metadata_folder' => $this->dir . '/idp_metadata/',
+        ];
+    }
+
+    public static function keyPair(string $cn) : array
+    {
+        return SignatureUtils::generateKeyCert([
+            'sp_org_name' => $cn,
+            'sp_org_display_name' => $cn,
+            'sp_key_cert_values' => [
+                'countryName' => 'IT',
+                'stateOrProvinceName' => 'Rome',
+                'localityName' => 'Rome',
+                'commonName' => $cn,
+                'emailAddress' => 'info@' . $cn,
+            ],
+        ]);
+    }
+
+    public function metadataFor(string $cert) : string
+    {
+        $clean = str_replace(
+            ['-----BEGIN CERTIFICATE-----', '-----END CERTIFICATE-----', "\r", "\n"],
+            '',
+            $cert
+        );
+        return '<?xml version="1.0"?>'
+            . '<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"'
+            . ' xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="' . $this->idpEntityId . '">'
+            . '<md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">'
+            . '<md:KeyDescriptor use="signing"><ds:KeyInfo><ds:X509Data><ds:X509Certificate>'
+            . $clean
+            . '</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor>'
+            . '<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"'
+            . ' Location="' . $this->idpEntityId . 'slo"/>'
+            . '<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"'
+            . ' Location="' . $this->idpEntityId . 'slo"/>'
+            . '<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"'
+            . ' Location="' . $this->idpEntityId . 'sso"/>'
+            . '<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"'
+            . ' Location="' . $this->idpEntityId . 'sso"/>'
+            . '</md:IDPSSODescriptor></md:EntityDescriptor>';
+    }
+
+    public function cleanUp()
+    {
+        foreach (['/idp_metadata/*', '/*'] as $pattern) {
+            foreach (glob($this->dir . $pattern) ?: [] as $f) {
+                if (is_link($f) || is_file($f)) {
+                    @unlink($f);
+                }
+            }
+        }
+        foreach (glob($this->dir . '/*', GLOB_ONLYDIR) ?: [] as $d) {
+            @rmdir($d);
+        }
+        @rmdir($this->dir . '/idp_metadata');
+        @rmdir($this->dir);
+    }
+
+    // ------------------------------------------------------------------
+    // Message builders
+    // ------------------------------------------------------------------
+
+    public function assertionXml(array $overrides = []) : string
+    {
+        $now = gmdate('Y-m-d\TH:i:s\Z');
+        $later = gmdate('Y-m-d\TH:i:s\Z', time() + 3600);
+        $v = array_merge([
+            'assertionId' => '_assertion0123456789abcdef',
+            'idpEntityId' => $this->idpEntityId,
+            'requestId' => $this->requestId,
+            'acsUrl' => $this->acsUrl,
+            'audience' => $this->spEntityId,
+            'fiscalNumber' => 'REAL-USER-FISCAL-CODE',
+            'authnContextClassRef' => 'https://www.spid.gov.it/SpidL2',
+            'extraAuthnContextClassRef' => '',
+        ], $overrides);
+
+        return '<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"'
+            . ' ID="' . $v['assertionId'] . '" Version="2.0" IssueInstant="' . $now . '">'
+            . '<saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">'
+            . $v['idpEntityId'] . '</saml:Issuer>'
+            . '<saml:Subject>'
+            . '<saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"'
+            . ' NameQualifier="' . $v['idpEntityId'] . '">_transient-name-id</saml:NameID>'
+            . '<saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">'
+            . '<saml:SubjectConfirmationData InResponseTo="' . $v['requestId'] . '"'
+            . ' NotOnOrAfter="' . $later . '" Recipient="' . $v['acsUrl'] . '"/>'
+            . '</saml:SubjectConfirmation></saml:Subject>'
+            . '<saml:Conditions NotBefore="' . $now . '" NotOnOrAfter="' . $later . '">'
+            . '<saml:AudienceRestriction><saml:Audience>' . $v['audience'] . '</saml:Audience>'
+            . '</saml:AudienceRestriction></saml:Conditions>'
+            . '<saml:AuthnStatement AuthnInstant="' . $now . '" SessionIndex="' . $v['assertionId'] . '">'
+            . '<saml:AuthnContext>'
+            . '<saml:AuthnContextClassRef>' . $v['authnContextClassRef'] . '</saml:AuthnContextClassRef>'
+            . $v['extraAuthnContextClassRef']
+            . '</saml:AuthnContext></saml:AuthnStatement>'
+            . '<saml:AttributeStatement>'
+            . '<saml:Attribute Name="fiscalNumber"><saml:AttributeValue>' . $v['fiscalNumber']
+            . '</saml:AttributeValue></saml:Attribute>'
+            . '</saml:AttributeStatement>'
+            . '</saml:Assertion>';
+    }
+
+    // Signs $xml with the Identity Provider key (or with $key/$cert when given) and
+    // strips the XML declaration so the result can be embedded in another document.
+    public function sign(string $xml, ?string $key = null, ?string $cert = null) : string
+    {
+        $signed = SignatureUtils::signXml($xml, [
+            'sp_key_file' => $key ?? $this->idpKey,
+            'sp_cert_file' => $cert ?? $this->idpCert,
+        ]);
+        return preg_replace('/^<\?xml[^>]*\?>\s*/', '', $signed);
+    }
+
+    public function signedAssertion(array $overrides = []) : string
+    {
+        return $this->sign($this->assertionXml($overrides));
+    }
+
+    public function response(string $body, array $overrides = []) : string
+    {
+        $now = gmdate('Y-m-d\TH:i:s\Z');
+        $v = array_merge([
+            'status' => 'urn:oasis:names:tc:SAML:2.0:status:Success',
+            'responseId' => '_response0123456789',
+            'requestId' => $this->requestId,
+            'acsUrl' => $this->acsUrl,
+            'idpEntityId' => $this->idpEntityId,
+        ], $overrides);
+
+        return '<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"'
+            . ' xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="' . $v['responseId'] . '"'
+            . ' Version="2.0" IssueInstant="' . $now . '" InResponseTo="' . $v['requestId'] . '"'
+            . ' Destination="' . $v['acsUrl'] . '">'
+            . '<saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">'
+            . $v['idpEntityId'] . '</saml:Issuer>'
+            . '<samlp:Status><samlp:StatusCode Value="' . $v['status'] . '"/></samlp:Status>'
+            . $body
+            . '</samlp:Response>';
+    }
+
+    public function logoutResponse(array $overrides = []) : string
+    {
+        $now = gmdate('Y-m-d\TH:i:s\Z');
+        $v = array_merge([
+            'status' => 'urn:oasis:names:tc:SAML:2.0:status:Success',
+            'id' => '_logoutresponse0123456789',
+            'requestId' => $this->requestId,
+            'destination' => $this->sloUrl,
+            'idpEntityId' => $this->idpEntityId,
+        ], $overrides);
+
+        return '<samlp:LogoutResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"'
+            . ' xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="' . $v['id'] . '"'
+            . ' Version="2.0" IssueInstant="' . $now . '" InResponseTo="' . $v['requestId'] . '"'
+            . ' Destination="' . $v['destination'] . '">'
+            . '<saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">'
+            . $v['idpEntityId'] . '</saml:Issuer>'
+            . '<samlp:Status><samlp:StatusCode Value="' . $v['status'] . '"/></samlp:Status>'
+            . '</samlp:LogoutResponse>';
+    }
+
+    public function logoutRequest(array $overrides = []) : string
+    {
+        $now = gmdate('Y-m-d\TH:i:s\Z');
+        $v = array_merge([
+            'id' => '_logoutrequest0123456789',
+            'destination' => $this->spEntityId,
+            'idpEntityId' => $this->idpEntityId,
+            'sessionIndex' => $this->requestId,
+        ], $overrides);
+
+        return '<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"'
+            . ' xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="' . $v['id'] . '"'
+            . ' Version="2.0" IssueInstant="' . $now . '" Destination="' . $v['destination'] . '">'
+            . '<saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity"'
+            . ' NameQualifier="' . $v['idpEntityId'] . '">' . $v['idpEntityId'] . '</saml:Issuer>'
+            . '<saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"'
+            . ' NameQualifier="' . $v['idpEntityId'] . '">_transient-name-id</saml:NameID>'
+            . '<samlp:SessionIndex>' . $v['sessionIndex'] . '</samlp:SessionIndex>'
+            . '</samlp:LogoutRequest>';
+    }
+
+    // ------------------------------------------------------------------
+    // Driving the library
+    // ------------------------------------------------------------------
+
+    // Seeds the session exactly as Idp::authnRequest would have, then hands the
+    // message to the library through the ACS entry point.
+    public function loginSession(array $overrides = []) : array
+    {
+        return array_merge([
+            'idpName' => 'idp',
+            'RequestID' => $this->requestId,
+            'acsUrl' => $this->acsUrl,
+            'idpEntityId' => $this->idpEntityId,
+        ], $overrides);
+    }
+
+    public function post(array $session, string $xml, string $param = 'SAMLResponse') : bool
+    {
+        // Build the Sp first: its constructor may call session_start(), which would
+        // reset $_SESSION. Populating the session afterwards keeps it.
+        $sp = new Italia\Spid\Sp($this->settings, null, false);
+        $_SESSION = $session;
+        $_POST[$param] = base64_encode($xml);
+        try {
+            return $sp->isAuthenticated();
+        } finally {
+            unset($_POST[$param]);
+        }
+    }
+
+    // Same, over the HTTP-Redirect binding, signing the query string with $key when
+    // one is given. Returns the result of isAuthenticated().
+    public function redirect(
+        array $session,
+        string $xml,
+        string $param = 'SAMLResponse',
+        ?string $key = null,
+        array $tamper = []
+    ) : bool {
+        $sp = new Italia\Spid\Sp($this->settings, null, false);
+        $_SESSION = $session;
+
+        $message = base64_encode(gzdeflate($xml));
+        $sigAlg = $tamper['SigAlg'] ?? 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
+
+        $_GET = [$param => $message, 'SigAlg' => $sigAlg];
+        if (isset($tamper['RelayState'])) {
+            $_GET['RelayState'] = $tamper['RelayState'];
+        }
+        if (!is_null($key)) {
+            $signed = $param . '=' . rawurlencode($message);
+            if (isset($tamper['RelayState'])) {
+                $signed .= '&RelayState=' . rawurlencode($tamper['RelayState']);
+            }
+            $signed .= '&SigAlg=' . rawurlencode($sigAlg);
+            openssl_sign($signed, $raw, openssl_get_privatekey(file_get_contents($key)), OPENSSL_ALGO_SHA256);
+            $_GET['Signature'] = $tamper['Signature'] ?? base64_encode($raw);
+        }
+        if (isset($tamper['QUERY_STRING'])) {
+            $_SERVER['QUERY_STRING'] = $tamper['QUERY_STRING'];
+        }
+        try {
+            return $sp->isAuthenticated();
+        } finally {
+            $_GET = [];
+            unset($_SERVER['QUERY_STRING']);
+        }
+    }
+}

--- a/tests/SpTest.php
+++ b/tests/SpTest.php
@@ -303,7 +303,9 @@ final class SpTest extends PHPUnit\Framework\TestCase
 
         foreach (self::$idps as $idp) {
             $retrievedIdp = $sp->loadIdpFromFile($idp);
-            $this->assertEquals($retrievedIdp->idpFileName, $idp);
+            // idpFileName is the canonical Identity Provider identifier, not the
+            // path the caller happened to pass in.
+            $this->assertEquals(basename($idp, '.xml'), $retrievedIdp->idpFileName);
 
             $metadata = $retrievedIdp->metadata;
 


### PR DESCRIPTION
A technical report reviewed `f5899eb` (the merge of #156) and found six issues. This closes all six, with regression tests for each.

## The bypass (critical)

A `Response` with `StatusCode=Success`, **no Assertion and no signature at all** produced an authenticated session. Reproduced on `f5899eb`:

```
isAuthenticated(): true
spidSession: {"level":"3","attributes":{"fiscalNumber":"ATTACKER-OWNED-FISCAL-CODE", …}}
```

Attacker-chosen attributes and SPID level, with no SPID identity, no assertion, no valid certificate and no IdP private key.

The cause is one line of policy: the signature requirement was derived from what the message happened to contain.

```php
$hasAssertion = $assertions->length > 0;
if ($hasAssertion && $signatures->length == 0) {   // no assertion → no signature needed
    throw new \Exception(…);
}
```

Every identity check downstream was inside `if ($hasAssertion)`, and `validateXmlSignature(null, $cert)` returned `true`, so a missing signature read as a verified one. #156 hardened the path where an assertion *is* present and left this branch as it was.

## What replaces it

The requirement is now decided by message type, before looking at content.

```mermaid
flowchart TD
    A[Incoming SAML message] --> B{samlp root element,<br/>and the document root?}
    B -- no --> R[Reject]
    B -- yes --> C{Message type}

    C -->|Response, Success| D{Exactly one Assertion,<br/>signed and verified?}
    D -- no --> R
    D -- yes --> S[Session built from<br/>that Assertion alone]

    C -->|Response, failure| E{Assertion present?}
    E -- yes --> R
    E -- no --> F[No session,<br/>report the failure]

    C -->|LogoutResponse / LogoutRequest| G{Binding}
    G -->|POST| H{XML signature on<br/>the root verified?}
    G -->|Redirect| I{SigAlg allowed and query<br/>Signature verified?}
    H -- no --> R
    I -- no --> R
    H -- yes --> J[Terminate the session]
    I -- yes --> J
```

Three consequences worth naming: `validateXmlSignature(null, …)` now returns `false`; the message must be the document root in the protocol namespace, so a `samlp:Response` nested inside an attacker's envelope is no longer read as the message; and identity comes out of the validated assertion through scoped, namespace-aware XPath rather than `getElementsByTagName()` over the whole document.

## The other five findings

| # | Finding | Fix |
|---|---|---|
| 2 | `Idp::loadFromXml()` used the caller's value as a file name as soon as it contained `idp_metadata_folder` anywhere inside it, then passed it to `file_exists()`/`simplexml_load_file()`. The X.509 cert in that metadata is the trust anchor for the Response, so choosing the file chose who may authenticate users — by traversal, absolute path, URL or stream wrapper. | The value is reduced to an IdP **name** resolved under `realpath()` of the folder. URLs and wrappers refused; paths accepted only when they point at a file directly in that folder (what `getIdpList()` passes). Only the canonical name reaches the session, and `example/views/login.php` validates `selected_idp` against `getIdpList()`. |
| 3 | The SPID level was `substr(AuthnContextClassRef, -1)` and was never compared with the requested one, so an IdP could answer SpidL1 to a request for SpidL2. | Requested level and `Comparison` recorded in the transaction; the asserted URI must be exactly `SpidL1`/`SpidL2`/`SpidL3`; comparison follows SAML 2.0 `RequestedAuthnContext/@Comparison`. The level is also validated on the way out, in `authnRequest()`. |
| 4 | Session id not regenerated on login (session fixation). | `session_regenerate_id(true)` immediately before the authenticated state is written. |
| 5 | An unsigned `LogoutResponse` reached the end of validation and tore the session down. The IdP-initiated path was unreachable through `SAMLRequest`, used `$issuer` before assigning it, read `Destination` off `Issuer`, treated `spidSession` as an object where `Response` stores an array, and compared `NameID` against a mistyped URN. `Idp::logoutResponse()` called `unset($_SESSION)`, which drops only the local reference and leaves the session alive. | All fixed; see the diagram for the signature policy. |
| 6 | `robrichards/xmlseclibs: ^3.0` allows versions affected by CVE-2019-3465, CVE-2025-66578 and CVE-2026-32313. | Raised to `^3.1.5`, and `composer audit` added to CI — which immediately surfaced CVE-2026-67434 in `squizlabs/php_codesniffer`, fixed here too. |

## Tests

41 → **101 tests / 183 assertions**, green on PHP 7.4 through 8.5, covering the regression lists in §1.6, §2.7, §3.5, §4.5 and §5.5 of the report, including its PoC. `phpcs --standard=PSR2`, `composer validate --strict` and `composer audit` all clean.

## Breaking changes

- `Session::$level` is an `int`, not a one-character string.
- An IdP must be selected by name; a path or URL is refused. `Idp::$idpFileName` is the canonical name, not the value passed in.
- A successful Response without a signed Assertion, and an unsigned logout message, are rejected rather than accepted.
- `ResponseInterface::validate()` receives the validated assertion element instead of a boolean.

Supersedes #157 by @VinsMach, which addressed the same report; its `authnRequest()` level guard is carried over here and credited in the code.
