### PR TITLE
Fix two fail-closed interop bugs from the audit fixes

### DIFF
--- a/src/Spid/Saml.php
+++ b/src/Spid/Saml.php
@@ -18,6 +18,15 @@ class Saml implements SAMLInterface
     public function __construct(array $settings, $autoconfigure = true)
     {
         Settings::validateSettings($settings);
+        if (isset($settings['sp_comparison'])) {
+            // The setting is validated case-insensitively, but the SAML schema
+            // defines Comparison as a lowercase enumeration and every use of the
+            // value compares it literally: the AuthnRequest attribute, the
+            // ForceAuthn decision, and the level check on the way back. Normalising
+            // here once keeps a configured "Minimum" from silently behaving as
+            // "exact" and rejecting a legitimate response.
+            $settings['sp_comparison'] = strtolower($settings['sp_comparison']);
+        }
         $this->settings = $settings;
 
         // Do not attemp autoconfiguration if key and cert values have not been set

--- a/src/Spid/Saml/In/BaseResponse.php
+++ b/src/Spid/Saml/In/BaseResponse.php
@@ -260,18 +260,14 @@ class BaseResponse
         if (!isset($_GET['Signature']) || !isset($_GET['SigAlg'])) {
             throw new \Exception("Invalid Response. Missing Signature or SigAlg on the query string");
         }
-        $this->assertNoDuplicateQueryParameters();
+        $raw = $this->rawQueryParameters();
 
         $sigAlg = $_GET['SigAlg'];
         if (!array_key_exists($sigAlg, self::REDIRECT_SIGNATURE_ALGOS)) {
             throw new \Exception("Invalid Response. Signature algorithm " . $sigAlg . " is not accepted");
         }
 
-        $signed = $this->messageParam . '=' . rawurlencode($_GET[$this->messageParam]);
-        if (isset($_GET['RelayState'])) {
-            $signed .= '&RelayState=' . rawurlencode($_GET['RelayState']);
-        }
-        $signed .= '&SigAlg=' . rawurlencode($sigAlg);
+        $signed = $this->signedQueryString($raw, $sigAlg);
 
         $signature = base64_decode($_GET['Signature'], true);
         if ($signature === false) {
@@ -286,25 +282,61 @@ class BaseResponse
         }
     }
 
-    // PHP keeps only the last occurrence of a repeated query parameter, so a
-    // duplicate would let the signature be verified over a different value than
-    // the one the rest of the code reads.
-    private function assertNoDuplicateQueryParameters()
+    // Rebuilds the octet string the Identity Provider actually signed.
+    //
+    // The bytes have to be taken from the raw query string. $_GET has already been
+    // percent-decoded, so re-encoding it amounts to guessing how the sender encoded
+    // the value in the first place: an Identity Provider that form-encodes a space
+    // in RelayState as "+", or uses lowercase percent escapes, signs a string that
+    // rawurlencode() does not reproduce, and a legitimate message gets rejected.
+    private function signedQueryString(?array $raw, string $sigAlg) : string
+    {
+        if (is_null($raw)) {
+            // No raw query string from this SAPI: fall back to re-encoding the
+            // decoded values, which is correct for an RFC 3986 encoded sender.
+            $signed = $this->messageParam . '=' . rawurlencode($_GET[$this->messageParam]);
+            if (isset($_GET['RelayState'])) {
+                $signed .= '&RelayState=' . rawurlencode($_GET['RelayState']);
+            }
+            return $signed . '&SigAlg=' . rawurlencode($sigAlg);
+        }
+
+        if (!array_key_exists($this->messageParam, $raw) || !array_key_exists('SigAlg', $raw)) {
+            throw new \Exception("Invalid Response. The query string does not carry the signed parameters");
+        }
+        // The binding fixes the order: message, then the optional RelayState, then
+        // SigAlg. Anything else in the query is not covered by the signature.
+        $parts = [$this->messageParam . '=' . $raw[$this->messageParam]];
+        if (array_key_exists('RelayState', $raw)) {
+            $parts[] = 'RelayState=' . $raw['RelayState'];
+        }
+        $parts[] = 'SigAlg=' . $raw['SigAlg'];
+        return implode('&', $parts);
+    }
+
+    // Splits the raw query string into name => still-encoded value, refusing any
+    // repeated parameter: PHP keeps only the last occurrence in $_GET, so a
+    // duplicate would let the signature be verified over a different value than the
+    // one the rest of the code reads. Returns null when the SAPI exposes no raw
+    // query string.
+    private function rawQueryParameters() : ?array
     {
         if (!isset($_SERVER['QUERY_STRING']) || $_SERVER['QUERY_STRING'] === '') {
-            return;
+            return null;
         }
-        $seen = [];
+        $raw = [];
         foreach (explode('&', $_SERVER['QUERY_STRING']) as $pair) {
             if ($pair === '') {
                 continue;
             }
-            $name = rawurldecode(explode('=', $pair, 2)[0]);
-            if (isset($seen[$name])) {
+            $split = explode('=', $pair, 2);
+            $name = rawurldecode($split[0]);
+            if (array_key_exists($name, $raw)) {
                 throw new \Exception("Invalid Response. Duplicate " . $name . " parameter on the query string");
             }
-            $seen[$name] = true;
+            $raw[$name] = $split[1] ?? '';
         }
+        return $raw;
     }
 
     // Rejects the response if any identity-bearing element exists outside the

--- a/src/Spid/Saml/In/Response.php
+++ b/src/Spid/Saml/In/Response.php
@@ -278,7 +278,9 @@ class Response implements ResponseInterface
             return $returned;
         }
         $requested = (int)$_SESSION['requestedLevel'];
-        $comparison = $_SESSION['requestedComparison'] ?? 'exact';
+        // Normalised when the settings are read, lowered again here so a session
+        // written by an older release still compares as intended.
+        $comparison = strtolower($_SESSION['requestedComparison'] ?? 'exact');
         if (!$this->levelSatisfies($returned, $requested, $comparison)) {
             throw new \Exception("Invalid Response. The Identity Provider returned SPID level " . $returned .
                 ", which does not satisfy the requested level " . $requested .

--- a/tests/LogoutSecurityTest.php
+++ b/tests/LogoutSecurityTest.php
@@ -121,6 +121,47 @@ final class LogoutSecurityTest extends TestCase
         $this->assertArrayNotHasKey('spidSession', $_SESSION);
     }
 
+    // The signed octet string has to be taken from the raw query string. An Identity
+    // Provider that form-encodes RelayState signs "RelayState=abc+def"; rebuilding
+    // it by re-encoding the value PHP already decoded yields "abc%20def" and rejects
+    // a perfectly good message.
+    public function testRedirectLogoutResponseWithFormEncodedRelayStateIsAccepted(): void
+    {
+        $this->assertFalse(self::$f->redirect(
+            $this->logoutSession(),
+            self::$f->logoutResponse(),
+            'SAMLResponse',
+            self::$f->idpKey,
+            ['rawRelayState' => 'abc+def']
+        ));
+        $this->assertArrayNotHasKey('spidSession', $_SESSION);
+    }
+
+    public function testRedirectLogoutResponseWithLowercasePercentEscapesIsAccepted(): void
+    {
+        $this->assertFalse(self::$f->redirect(
+            $this->logoutSession(),
+            self::$f->logoutResponse(),
+            'SAMLResponse',
+            self::$f->idpKey,
+            ['rawRelayState' => 'a%2fb']
+        ));
+        $this->assertArrayNotHasKey('spidSession', $_SESSION);
+    }
+
+    // RelayState is covered by the signature: changing it after signing must fail.
+    public function testRedirectLogoutResponseWithTamperedRelayStateIsRejected(): void
+    {
+        $this->expectException(\Exception::class);
+        self::$f->redirect(
+            $this->logoutSession(),
+            self::$f->logoutResponse(),
+            'SAMLResponse',
+            self::$f->idpKey,
+            ['RelayState' => 'https://sp.example.com/home', 'swapRelayState' => 'https://attacker.example/']
+        );
+    }
+
     public function testRedirectLogoutResponseWithoutSignatureIsRejected(): void
     {
         $this->expectException(\Exception::class);

--- a/tests/ResponseSecurityTest.php
+++ b/tests/ResponseSecurityTest.php
@@ -250,6 +250,34 @@ final class ResponseSecurityTest extends TestCase
         $this->assertSame(3, $_SESSION['spidSession']['level']);
     }
 
+    // Settings::validateSettings() accepts sp_comparison case-insensitively, so a
+    // deployment may legitimately configure "Minimum". Every use of the value
+    // compares it literally, and the SAML schema wants it lowercase, so it is
+    // normalised when the settings are read: otherwise "Minimum" silently behaved
+    // as "exact" and a genuine SpidL3 answer to a minimum-L2 request was refused.
+    /**
+     * @dataProvider comparisonSpellings
+     */
+    public function testComparisonIsCaseInsensitive(string $spelling): void
+    {
+        $settings = array_merge(self::$f->settings, ['sp_comparison' => $spelling]);
+        $saml = new Italia\Spid\Spid\Saml($settings, false);
+        $this->assertSame('minimum', $saml->settings['sp_comparison']);
+
+        $response = self::$f->response(
+            self::$f->signedAssertion(['authnContextClassRef' => 'https://www.spid.gov.it/SpidL3'])
+        );
+        $session = $this->session(['requestedLevel' => 2, 'requestedComparison' => $spelling]);
+
+        $this->assertTrue(self::$f->post($session, $response));
+        $this->assertSame(3, $_SESSION['spidSession']['level']);
+    }
+
+    public function comparisonSpellings(): array
+    {
+        return [['minimum'], ['Minimum'], ['MINIMUM']];
+    }
+
     public function testBetterComparisonRejectsAnEqualLevel(): void
     {
         $response = self::$f->response(self::$f->signedAssertion());

--- a/tests/SamlFixture.php
+++ b/tests/SamlFixture.php
@@ -284,22 +284,40 @@ class SamlFixture
         $message = base64_encode(gzdeflate($xml));
         $sigAlg = $tamper['SigAlg'] ?? 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
 
-        $_GET = [$param => $message, 'SigAlg' => $sigAlg];
-        if (isset($tamper['RelayState'])) {
-            $_GET['RelayState'] = $tamper['RelayState'];
+        // Build the query string the way an Identity Provider would and sign exactly
+        // those bytes, so the test exercises the real reconstruction path.
+        // 'rawRelayState' injects an already-encoded value, which is how a sender
+        // that form-encodes (a space as '+') would put it on the wire.
+        $pairs = [$param . '=' . rawurlencode($message)];
+        if (isset($tamper['rawRelayState'])) {
+            $pairs[] = 'RelayState=' . $tamper['rawRelayState'];
+        } elseif (isset($tamper['RelayState'])) {
+            $pairs[] = 'RelayState=' . rawurlencode($tamper['RelayState']);
         }
+        $pairs[] = 'SigAlg=' . rawurlencode($sigAlg);
+        $signed = implode('&', $pairs);
+
+        $query = $signed;
         if (!is_null($key)) {
-            $signed = $param . '=' . rawurlencode($message);
-            if (isset($tamper['RelayState'])) {
-                $signed .= '&RelayState=' . rawurlencode($tamper['RelayState']);
-            }
-            $signed .= '&SigAlg=' . rawurlencode($sigAlg);
             openssl_sign($signed, $raw, openssl_get_privatekey(file_get_contents($key)), OPENSSL_ALGO_SHA256);
-            $_GET['Signature'] = $tamper['Signature'] ?? base64_encode($raw);
+            $signature = $tamper['Signature'] ?? base64_encode($raw);
+            $query .= '&Signature=' . rawurlencode($signature);
+        }
+        // Replaces RelayState after the signature was computed over the original.
+        if (isset($tamper['swapRelayState'])) {
+            $query = preg_replace(
+                '/RelayState=[^&]*/',
+                'RelayState=' . rawurlencode($tamper['swapRelayState']),
+                $query
+            );
         }
         if (isset($tamper['QUERY_STRING'])) {
-            $_SERVER['QUERY_STRING'] = $tamper['QUERY_STRING'];
+            $query = $tamper['QUERY_STRING'];
         }
+
+        $_SERVER['QUERY_STRING'] = $query;
+        $_GET = [];
+        parse_str($query, $_GET);
         try {
             return $sp->isAuthenticated();
         } finally {


### PR DESCRIPTION
Follow-up to #158. An independent review of `d456f44` found two bugs in what that PR added. **Neither is a bypass** — both reject legitimate traffic, which is the safe direction to fail but breaks real logins and logouts. Each is proved by a test that fails without the fix.

## 1. `sp_comparison` was compared case-sensitively

`Settings::validateSettings()` accepts the value with `strcasecmp`, so `'Minimum'` is a valid configuration. `Response::levelSatisfies()` matched it with a case-sensitive `switch`, so it fell through to `default: exact` — and a genuine **SpidL3 answer to a `minimum` SpidL2 request was refused**.

The review flagged the comparison. Looking at where the value goes, it is wider than that: the same verbatim string is interpolated into

- `Comparison="$comparison"` in the AuthnRequest, and the SAML schema defines that attribute as the lowercase enumeration `exact|minimum|maximum|better`, so `Comparison="Minimum"` is schema-invalid on the wire;
- `$force = ($level > 1 || $comparison == "minimum")`, so `'Minimum'` at level 1 sent `ForceAuthn="false"` where `'minimum'` sent `"true"`.

Fixed by normalising once in `Saml::__construct()`, where the settings are read, so the AuthnRequest attribute, the `ForceAuthn` decision and the level check all agree. `validateLevel()` also lowercases what it reads back, so a session written by an older release still compares as intended.

## 2. The HTTP-Redirect signature was verified over a re-encoded string

`validateQuerySignature()` rebuilt the signed octet string with `rawurlencode($_GET[…])`. `$_GET` has already been percent-decoded, so re-encoding it guesses how the sender encoded the value in the first place. An IdP that form-encodes a space in `RelayState` as `+`, or uses lowercase percent escapes, signs bytes `rawurlencode()` does not reproduce:

| IdP sends and signs | rebuilt from `$_GET` | result |
|---|---|---|
| `RelayState=abc+def` | `RelayState=abc%20def` | rejected |
| `RelayState=a%2fb` | `RelayState=a%2Fb` | rejected |

The octet string now comes from the raw `QUERY_STRING` — which `assertNoDuplicateQueryParameters()` was already reading, so the raw bytes were there all along. The re-encoding survives only as a fallback for a SAPI that exposes no raw query string. Duplicate-parameter rejection is folded into the same parse.

The `tests/SamlFixture.php` redirect helper now builds a real query string and populates `$_GET` with `parse_str()`, so these tests exercise the reconstruction path instead of bypassing it.

## Tests

101 → **107 tests / 197 assertions**, green on PHP 7.4 through 8.5, lint clean. The four new regression tests fail on `d456f44`:

```
1) …testRedirectLogoutResponseWithFormEncodedRelayStateIsAccepted
   Exception: Invalid Response. Query string signature validation failed
2) …testRedirectLogoutResponseWithLowercasePercentEscapesIsAccepted
   Exception: Invalid Response. Query string signature validation failed
3) …testComparisonIsCaseInsensitive with data set #1 ('Minimum')
4) …testComparisonIsCaseInsensitive with data set #2 ('MINIMUM')
```

A fifth test pins that `RelayState` really is covered by the signature — it passed before too, and is here as a guard so the raw-bytes change cannot loosen it.

## What the review did not find

No remaining bypass. Verified by running code against `d456f44`: the original PoC, a Response signed on both root and Assertion (accepted — no regression), root-signed with an unsigned Assertion (rejected), nested `StatusCode` playing `BaseResponse::isSuccess()` against `Response::validate()` (rejected — the "Unexpected Assertion" guard makes the two parsers impossible to disagree in a way that yields a session), and comment-splitting inside a signed `AttributeValue` (`REAL<!--x-->EVIL` reads as the full concatenated `nodeValue`, which is what without-comments C14N signs, so no CVE-2017-11428-style split).

The `sp_comparison` handling was already correct in #157 by @VinsMach.